### PR TITLE
Force build before test to avoid false positives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ node_js:
   - "0.9"
   - "0.10"
   - "0.11"
-script: "node ./test/node.js"
+script: "make riot && node ./test/node.js"

--- a/lib/render.js
+++ b/lib/render.js
@@ -23,16 +23,16 @@ $.render = function(template, data) {
   if(!template) return '';
 
   FN[template] = FN[template] || new Function("_", "E",
+    "function C(v){return (v===null||v===false?'':v+'').replace(/[&\"<>]/g,function(e){return E[e];})}"+
     "return '" + template
       .replace(
         /[\\\n\r\u2028\u2029']/g,
         function(escape) { return ESCAPING_MAP[escape]; }
       ).replace(
         /\{\s*([\.\w]+)\s*\}/g,
-        "'+(function(){try{return(typeof(_.$1)!=='undefined'?(_.$1+'').replace(/[&\"<>]/g,function(e){return E[e];}):'')}catch(e){return ''}})()+'"
+        "'+(function(){try{return(typeof(_.$1)!=='undefined'?C(_.$1):'')}catch(e){return ''}})()+'"
       )+"'"
   );
 
   return FN[template](data, ENTITIES_MAP);
 };
-


### PR DESCRIPTION
If a commit eg: f916185 doesn't build the riot.js file it may pass CI although it fails the tests after building. This should help that situation.

This is the failing test I'm seeing:

```
--- $.render ---
Single token
Multiple tokens
Single quotes
Empty value

AssertionError: "null" != ""
...
at ... riotjs/test/render_test.js:21:12
```

