### PR TITLE
added rootNode parameter to riot.mount

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -383,12 +383,12 @@
     return tag && createTag({ tmpl: tag[0], fn: tag[1], root: node, opts: opts })
   }
 
-  riot.mount = function(selector, opts) {
+  riot.mount = function(selector, opts, rootNode) {
     if (selector == '*') selector = Object.keys(tag_impl).join(', ')
 
     var instances = []
 
-    each(doc.querySelectorAll(selector), function(node) {
+    each((rootNode || doc).querySelectorAll(selector), function(node) {
       if (node.riot) return
 
       var tagName = node.tagName.toLowerCase(),


### PR DESCRIPTION
add rootNode parameter to riot.mount to allow multiple/different mounting on one page