### PR TITLE
add jshint check before concat

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,9 @@
 {
-  "globals": {
-    "$": false
-  },
-  "-W054": true,
-  "expr": true
+  "expr": true,
+  "asi": true,
+  "laxbreak": true,
+  "eqnull": true,
+  "evil": true,
+  "-W093": true,
+  "-W067": true
 }

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ jshint:
 dev:
 	@ node make/dev.js
 
-riot:
+riot: jshint
 	@ mkdir -p dist
 	@ cat make/prefix.js | sed "s/VERSION/$(VERSION)/" > dist/riot.js
 	@ cat lib/* >> dist/riot.js

--- a/lib/view.js
+++ b/lib/view.js
@@ -286,7 +286,6 @@
         els = val.split(/\s+in\s+/),
         rendered = [],
         checksum,
-        root,
         keys
 
 


### PR DESCRIPTION
- suppresses warnings about == null comparisons
- suppresses warnings about missing semicolons
- suppresses warnings about possibly unsafe line breakings

etc.