### PR TITLE
Export compile function

### DIFF
--- a/compiler/index.js
+++ b/compiler/index.js
@@ -115,7 +115,7 @@ var self = module.exports = {
     ;(opt.flow[1] == 'f' ? toFile : toDir)(from, to)
 
     // Print what's been done
-    
+
     from.map(function(src, i) {
       log(toRelative(src) + ' -> ' + toRelative(to[i] || to[0]))
     })
@@ -129,12 +129,15 @@ var self = module.exports = {
     self.make(opt)
 
     var glob = opt.flow[0] == 'f' ? opt.from : ph.join(opt.from, '**/*.tag')
-    
+
     chokidar.watch(glob, { ignoreInitial: true })
       .on('ready', function() { log('Watching ' + toRelative(glob)) })
       .on('all', function(e, path) { self.make(opt) })
 
-  }
+  },
+
+
+  compile: compile
 
 }
 
@@ -187,4 +190,3 @@ function cli() {
 
 
 if (!module.parent) cli()
-


### PR DESCRIPTION
I do not know how to compile `*.tag` file from code, for example:

```js
var compile = require('riot');
var fs = require('fs');

fs.writeFileSync(compile(fs.readFileSync('hoge.tag')), 'hoge.js');
```

This raised error. So I think it should export `compiler/compile.js`. If export this function:

```js
var compile = require('riot').compile;
var fs = require('fs');

fs.writeFileSync(compile(fs.readFileSync('hoge.tag')), 'hoge.js');
```

It works.

Thanks