### PR TITLE
Add semicolon to end of riot.tag()

### DIFF
--- a/compiler/compile.js
+++ b/compiler/compile.js
@@ -70,7 +70,7 @@ module.exports = function(input, opts) {
 
         html = tag = ''
 
-        out.push('})')
+        out.push('});')
 
       // tag start
       } else {


### PR DESCRIPTION
Ran into mising semicolon errors as am running the compiled tag JS through jsHint. This seems to solve part of the problem.