### PR TITLE
Fix wrong identify index of array loop

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -348,7 +348,7 @@
         if (keys && !checksum) {
           var obj = {}
           obj[keys[0]] = item
-          obj[keys[1]] = i
+          obj[keys[1]] = pos
           item = obj
         }
 


### PR DESCRIPTION
Currently riotjs uses an array of difference between the mounted data and recent updated data and sets the index from this difference. 
When you define a loop, waits that the index is the current matrix and not the your difference.

@example
<todo each={ obj, index in items }>...

Currently index is a index of a difference. This patch use a pos value returned by indexOf.