### PR TITLE
fixing typo, .one('mount' -> .on('mount'

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -295,7 +295,7 @@
     }
 
     // clean template code
-    instance.one('mount', function() {
+    instance.on('mount', function() {
       var p = dom.parentNode
       if (p) {
         root = p


### PR DESCRIPTION
I might be wrong, but I think .one should be .on here.
