### PR TITLE
Add jade preprocess feature

### DIFF
--- a/compiler/compiler.js
+++ b/compiler/compiler.js
@@ -70,6 +70,10 @@ function typescript(js) {
   return require('typescript-simple')(js)
 }
 
+function jade(html) {
+  return require('jade').render(html, {pretty: true})
+}
+
 function plainjs(js) {
   return js
 }
@@ -117,6 +121,9 @@ var PARSERS = {
   typescript: typescript
 }
 
+var TEMPLATE_PARSERS = {
+  jade: jade
+}
 
 function compileJS(js, opts, type) {
   var parser = opts.parser || (type ? PARSERS[type] : riotjs)
@@ -124,9 +131,19 @@ function compileJS(js, opts, type) {
   return parser(js, opts)
 }
 
+function compileTemplate(lang, html) {
+  var parser = TEMPLATE_PARSERS[lang]
+  if (!parser) throw new Error('Template parser not found "' + lang + '"')
+  return parser(html)
+}
+
 function compile(riot_tag, opts) {
 
   opts = opts || {}
+
+  if (opts.template) {
+    riot_tag = compileTemplate(opts.template, riot_tag)
+  }
 
   return riot_tag.replace(CUSTOM_TAG, function(_, tagName, html, js) {
 

--- a/compiler/index.js
+++ b/compiler/index.js
@@ -22,6 +22,7 @@ function help() {
     '  -w, --watch     Watch for changes',
     '  -c, --compact   Minify </p> <p> to </p><p>',
     '  -t, --type      JavaScript parser: none, es6, coffeescript ...',
+    '  --template      HTML pre-processor: jade...',
     '  --expr          Run expressions trough parser defined with --type',
     '',
     'Build a single .tag file:',
@@ -175,7 +176,8 @@ function cli() {
     compile_opts: {
       compact: args.compact,
       type: args.type,
-      expr: args.expr
+      expr: args.expr,
+      template: args.template
     },
     from: args._.shift(),
     to: args._.shift()
@@ -195,4 +197,3 @@ function cli() {
 
 
 if (!module.parent) cli()
-


### PR DESCRIPTION
for #237

```
✈ cat sample.tag
sample
  p test { value }
  script(type='text/coffeescript').
    @value = 'sample'
✈ node compiler/index.js --template jade sample.tag
  sample.tag -> sample.js
✈ cat sample.js

riot.tag('sample', '<p>test { value }</p>', function(opts) {this.value = 'sample';

});
```

:v: 