### PR TITLE
For boolean attributes, also set the DOM attribute

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -112,6 +112,7 @@
       // normal attribute
       } else {
         if (expr.bool) {
+          dom[attr_name] = value
           if (!value) return
           value = attr_name
         }


### PR DESCRIPTION
The DOM attribute represents the state - if the user has interacted with an element then just changing the attribute may not update the state (it doesn't in the latest Firefox and Chrome, for example)..

[Pared-down test case showing current behaviour](http://bl.ocks.org/insin/4ce0df7537a567f1eecb)