### PR TITLE
Duplicate plainjs() removal

### DIFF
--- a/compiler/compiler.js
+++ b/compiler/compiler.js
@@ -94,10 +94,6 @@
     return require('typescript-simple')(js)
   }
 
-  function plainjs(js) {
-    return js
-  }
-
   function jade(html) {
     return require('jade').render(html, {pretty: true})
   }


### PR DESCRIPTION
Removed duplicate. First instance on lines 89-91

```js
function plainjs(js) {
    return js
}
```