### PR TITLE
Throw an invalid .tag file error when files will not compile

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -152,7 +152,7 @@
 
     if (opts.template) riot_tag = compileTemplate(opts.template, riot_tag)
 
-    return riot_tag.replace(CUSTOM_TAG, function(_, tagName, html, js) {
+    var output = riot_tag.replace(CUSTOM_TAG, function(_, tagName, html, js) {
 
       html = html || ''
 
@@ -169,10 +169,14 @@
 
       return 'riot.tag(\'' +tagName+ '\', \'' + compileHTML(html, opts, type) + '\', function(opts) {' +
         compileJS(js, opts, type) +
-      '\n});'
-
+        '\n});'
     })
 
+    if (!output.match(/^riot\.tag/)) {
+      throw new Error("Invalid .tag file. Check the file beginning with '"+riot_tag.split("\n")[0] + "'");
+    } else {
+      return output;
+    }
   }
 
 


### PR DESCRIPTION
This is better than silently returning the original, unchanged input.