### PR TITLE
remove objects from all_tags when removed from the dom

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -322,6 +322,15 @@
       return Array.prototype.indexOf.call(root.childNodes, prev) + 1
     }
 
+    function removeChildTags(parent) {
+      for(var i = all_tags.length -1; i >=0; i--) {
+        if(all_tags[i].parent == parent) {
+          removeChildTags(all_tags[i])
+        }
+      }
+      all_tags.splice(all_tags.indexOf(parent),1)
+    }
+
     instance.on('updated', function() {
 
       var items = tmpl(val, instance),
@@ -352,6 +361,12 @@
         var pos = rendered.indexOf(item)
         root.removeChild(root.childNodes[startPos() + pos])
         rendered.splice(pos, 1)
+        var atag = all_tags.filter(function(t) {
+          return t.__item == item
+        })
+        if(atag.length == 1) {
+          removeChildTags(atag[0])
+        }
       })
 
       // add new


### PR DESCRIPTION
This fixes the memory leaks when removing objects ref: #248 