### PR TITLE
Fix close tag regexp

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -26,7 +26,7 @@
   var CUSTOM_TAG = /^<([\w\-]+)>([^\x00]*[\w\/]>$)?([^\x00]*?)^<\/\1>/gim,
       SCRIPT = /<script(\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/script>/gm,
       HTML_COMMENT = /<!--.*?-->/g,
-      CLOSED_TAG = /<([\w\-]+)([^\/]*)\/\s*>/g,
+      CLOSED_TAG = /<([^<>]*)\/>/g,
       LINE_COMMENT = /^\s*\/\/.*$/gm,
       JS_COMMENT = /\/\*[^\x00]*?\*\//gm
 
@@ -56,7 +56,10 @@
     }
 
     // <foo/> -> <foo></foo>
-    html = html.replace(CLOSED_TAG, function(_, name, attr) {
+    html = html.replace(CLOSED_TAG, function(_, elm) {
+      var elm = elm.split(' ')
+      var name = elm[0]
+      var attr = elm.slice(1).join(' ')
       var tag = '<' + name + (attr ? ' ' + attr.trim() : '') + '>'
 
       // Do not self-close HTML5 void tags


### PR DESCRIPTION
Hi

`riot@2.0.7` compiler is broken. Example:

```
<tag>
  <form>
    <input type='text' />
    <button>submit</button>
  </form>
</tag>
```

compiles:

```
riot.tag('tag', '<form > <input type=\'text\'></form> <button>submit</button> </form>', function(opts) {

});
```

Two `</form>` generated.

This caused by `CLOSED_TAG` RegExp. `/<([\w\-]+)([^\/]*)\/\s*>/` matches `<p/>` but `<form> <input type='text' />` is also match. This pattern is `name = 'form', attr = "> <input type='text' "` (https://github.com/muut/riotjs/blob/e98178bbd3a7ea3462c952bfe6ad991f6a03111e/lib/compiler.js#L58-L65). So compiled result is above.

This PR is fixing this problem.