### PR TITLE
emit always hashchange (workaround to page load problem)

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -17,20 +17,20 @@
     return path.split('/')
   }
 
-  function emit(path) {
+  function emit(path, force) {
     if (path.type) path = hash()
 
-    if (path != current) {
+    if (force || path != current) {
       fns.trigger.apply(null, ['H'].concat(parser(path)))
       current = path
     }
   }
 
-  var r = riot.route = function(arg) {
+  var r = riot.route = function(arg, force) {
     // string
     if (arg[0]) {
       loc.hash = arg
-      emit(arg)
+      emit(arg, force)
 
     // function
     } else {


### PR DESCRIPTION
I've a problem with the initial ``DOMContentLoaded`` event.
I'm using bootstrap ``navbar``. All tags are invisible at mount time.
After mounting, I need trigger a page route ``riot.route(page, true);`` to allow tags to become visible
if they are supposed to be visible.
I have to this, because no ``hashchange`` is fired by the browser on ``DOMContentLoaded`` event and therefore from the router.
Are there other solutions to this problem?

```javascript
$(() => {
  riot.mount('*');
  riot.route.exec(page => {
    if (page === '') {
      riot.route('status');
    } else {
      riot.route(page, true);
    }
  });
});
```

I've updated the pull request. Now riot.route takes a second boolean parameter.