### PR TITLE
Fixing line break issue

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -51,7 +51,7 @@
     // run trough parser
     if (opts.expr) {
       html = html.replace(/\{\s*([^\}]+)\s*\}/g, function(_, expr) {
-         return '{' + compileJS(expr, opts, type).trim() + '}'
+         return '{' + compileJS(expr, opts, type).trim().replace(/\r?\n|\r/g, '') + '}'
       })
     }
 


### PR DESCRIPTION
We need to remove line breaks as well as trim whitespace when evaluating expressions because the compiler (in my case CoffeeScript) may return them. Line breaks break the template string and raise an error: Unexpected token ILLEGAL.