### PR TITLE
Compile all of the constructor function

### DIFF
--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -332,10 +332,10 @@ After the tag is defined you can use it inside other tags. For example
 
 ```
 <my-tag>
-  <p>Here is some raw content: <raw content="{ html }"/> </p>
+  <p>Here is some raw content: <raw content="{ html }"></raw> </p>
 
-  this.html = 'Hello, <strong>world!</raw>'
-</raw>
+  this.html = 'Hello, <strong>world!</strong>';
+</my-tag>
 ```
 
 [demo on jsfiddle](http://jsfiddle.net/23g73yvx/)

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -167,9 +167,7 @@
         })
       }
 
-      return 'riot.tag(\'' +tagName+ '\', \'' + compileHTML(html, opts, type) + '\', function(opts) {' +
-        compileJS(js, opts, type) +
-      '\n});'
+      return compileJS('riot.tag(\'' + tagName + '\', \'' + compileHTML(html, opts, type) + '\', function(opts) {' + js + '\n});', opts, type)
 
     })
 


### PR DESCRIPTION
Compile all of the constructor function (not just the body). This stops 'top level this' reference errors generated by 6to5 when compiling ES6 tags.

For example, here's what happens compiling the example ES6 `test` tag from the compiler documentation https://muut.com/riotjs/compiler.html#ecmascript-6

```
$ riot  --type es6 es6-test.tag

ReferenceError: unknown: Line 4: Top level `this` is `undefined` in strict mode
  2  |
  3  |   var type = 'JavaScript'
> 4  |   this.test = `This is ${type}`
     |   ^
```  
