### PR TITLE
Don't use setAttribute when updating 'value'

### DIFF
--- a/lib/tag/update.js
+++ b/lib/tag/update.js
@@ -58,8 +58,12 @@ function update(expressions, tag, item) {
         if (!value) return
         value = attr_name
       }
-
-      dom.setAttribute(attr_name, value)
+      if(attr_name == 'value'){
+        dom.value = attr_name
+      }else{
+        dom.setAttribute(attr_name, value)
+      }
+      
     }
 
   })


### PR DESCRIPTION
When updating a value, for example for an input field,
updating the attributes value change the default value, so has no effect for later updates.
In the specific case, we should update the 'value' key of the dom object instead of the attribute.