### PR TITLE
Don't use setAttribute when updating 'value'

### DIFF
--- a/lib/tag/update.js
+++ b/lib/tag/update.js
@@ -76,6 +76,10 @@ function update(expressions, tag, item) {
       dom.style.display = value ? '' : 'none'
 
     // normal attribute
+    } else if (attr_name == 'value'){
+      if(dom.value !== value){
+        dom.value = value  
+      } 
     } else {
       if (expr.bool) {
         dom[attr_name] = value


### PR DESCRIPTION
This is following https://github.com/muut/riotjs/pull/299

When updating a value, for example for an input field,
updating the attributes value change the default value, so has no effect for later updates, once the filed has been changed by the user.
In the specific case, we should update the 'value' key of the dom object instead of the attribute.