### PR TITLE
Expose `riot._view` for CommonJS to reinitialize view library

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -1,12 +1,13 @@
 
-;(function(riot, is_browser) {
+riot._view = function(global) {
 
-  if (!is_browser) return
+  if (!global.top) return
 
-  var tmpl = riot._tmpl,
+  var riot = this,
+      tmpl = riot._tmpl,
       all_tags = [],
       tag_impl = {},
-      doc = document
+      doc = global.document
 
   function each(nodes, fn) {
     for (var i = 0; i < (nodes || []).length; i++) {
@@ -424,5 +425,6 @@
     })
   }
 
-})(riot, this.top)
+}
+riot._view(this)
 


### PR DESCRIPTION
This pull request enables reinitializing riot view library for Node.js DOM library like [jsdom](https://github.com/tmpvar/jsdom) by exposing `riot._view` function.
Jsdom can generate `Window` object without browsers, so we can mount riot tag separate from browsers.

```javascript
var window = require('jsdom').jsdom('<body><foo /></body>').parentWindow;
var riot = require('riot/riot');
riot._view(window);
//  riot.tag, riot.mount etc.
```