### PR TITLE
Add semicolons at beginning/end of main function

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -1,6 +1,6 @@
 
 
-(function(is_node) {
+;(function(is_node) {
 
   var BOOL_ATTR = ('allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare,default,'+
     'defaultchecked,defaultmuted,defaultselected,defer,disabled,draggable,enabled,formnovalidate,hidden,'+
@@ -280,4 +280,4 @@
     return browserCompile(str, true)
   }
 
-})(!this.top)
+})(!this.top);


### PR DESCRIPTION
Match the style from https://github.com/muut/riotjs/blob/master/riot.js which begins and ends with a semicolon.

Right now this causes problems when generating `riot+compiler.js` which turns into a TypeError. Closes #315 