### PR TITLE
Avoid invalid javascript loaded in the browser

### DIFF
--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -137,7 +137,7 @@ Once a tag is created you can mount it on the page as follows:
   &lt;script src="riot.min.js"></script>
 
   <!-- include the tag -->
-  &lt;script src="todo.js"></script>
+  &lt;script src="todo.js" type="riot/tag"></script>
 
   <!-- mount the tag -->
   &lt;script>riot.mount('todo')</script>


### PR DESCRIPTION
When using the example directly from the documentation it will try to load to `todo.js` (or whatever you call it) as javascript. This minor change will make sure that you can follow the guide.