### PR TITLE
Fixed "noop is not defined"

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -388,7 +388,7 @@
   }
 
   riot.tag = function(name, tmpl, fn) {
-    fn = fn || noop,
+    fn = fn || function() {},
     tag_impl[name] = [tmpl, fn]
   }
 


### PR DESCRIPTION
If `.tag()` is called without a constructor an uncaught reference error is raised. This fixed that.