### PR TITLE
Update gitignore file to use the ones provided by github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,61 @@
-.*
-!.editorconfig
-!.jshintrc
-!.gitignore
-!.gitmodules
-!.travis.yml
-*~
+# --------------------
+# OSX Files
+# --------------------
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
 
-node_modules
-bower_components
+# --------------------
+# Windows Files
+# --------------------
 Thumbs.db
 ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
-.DS_Store
+*.cab
+*.msi
+*.msm
+*.msp
+*.lnk
+
+# --------------------
+# Sublime Text Files
+# --------------------
+*.sublime-project
+*.sublime-workspace
+
+# --------------------
+# IntelliJ Files
+# --------------------
+*.iml
+*.ipr
+*.iws
+.idea/
+out/
+
+# --------------------
+# Eclipse Files
+# --------------------
+.project
+.metadata
+*.bak
+.classpath
+.settings/
+
+# --------------------
+# App Files
+# --------------------
+node_modules
+npm-debug.log
+bower_components
+coverage
 dist
-npm-debug.log 
 make.js
 test/server
+
+!.gitmodules
+!.travis.yml


### PR DESCRIPTION
This PR creates a gitignore file by compiling the amazing work done in the [github gitignore](https://github.com/github/gitignore) project. Since this is gaining a lot of support I added ignores for the 3 most popular IDEs as well as full ignores for OSX and Windows. I also tried to organize what you already had since a lot of it fit into those categories already.

The only thing I removed was lines 1-4 and 7 in the original gitignore as they don't appear to be doing anything. It's very possible I misunderstood so I'm happy to push an update if that was in error.
