### PR TITLE
fix issue with mount('*') when doing transclusion

### DIFF
--- a/lib/tag/vdom.js
+++ b/lib/tag/vdom.js
@@ -34,6 +34,7 @@ riot.mount = function(selector, opts) {
   var tags = []
 
   each(document.querySelectorAll(selector), function(root) {
+    if (root.riot) return
 
     var tagName = root.tagName.toLowerCase(),
         tag = mountTo(root, tagName, opts)


### PR DESCRIPTION
I have following markup on the page
```jade
tabs
  tab(title="First")
    p First tab content
  tab(title="Second")
    p Second tab content
  tab(title="Third")
    p Third tab content
```
and tags
```jade
tabs
  ul.nav.nav-tabs
    li(class='{active:tab.isActive}' each='{tab in tabs}')
      a(href='#' onclick='{parent.selectTab}') {tab.title}

  .tabs-wrapper(name='wrapper')

  script.
    //- transclude
    while (this.root.firstChild) {
      this.wrapper.appendChild(this.root.firstChild)
    }
    this.on('mount', function() {
      this.tabs = this.children.slice()
      var active = this.tabs.filter(function(tab) { return tab.isActive })
      if (this.tabs.length && !active.length) {
        this.tabs[0].isActive = true
      }
      this.update()
    })
    this.selectTab = function(event) {
      this.tabs.forEach(function(tab) { tab.isActive = false })
      event.item.tab.isActive = true
      this.update()
    }.bind(this)


tab
  .tab-content(name='content' show='{isActive}')

  script.
    //- transclude
    while (this.root.firstChild) {
      this.content.appendChild(this.root.firstChild)
    }
    this.on('mount', function() {
      this.title = this.root.getAttribute('title')
    })
```

There is an issues with riot.mount('*') in WIP, 2.0.8 doing fine.

my example in WIP working this way:
1. mount call querySelectorAll which collects all tags from page dom and then mountTo all of it 
2. during creation of <tabs> it's inner dom from page transcluded to template
3. parseLayout create tags for all <tab> transcluded to <tabs> template
4. <tabs> fires 'mount' event and configure it's <tab>s
5. mount get <tab> collected on step 1, tag for it is already created on step 3, but mountTo force creation of new one

Forcing creation of already mounted tag is this case have following issues:
1. inner dom of <tab> is already transcluded to template and configured template moved to page dom, when force creation of it again transclude will get already configured template from page dom instead of original dom, so <tab> get wrapped in another <tab>
2. on step 4 <tabs> configure it's 3 <tab>s, but when mountTo create new tags for <tab> it's not removing original one, so <tags> will have 6 child <tab>s instead of 3, last 3 <tab>s are not configured during 'mount' event, so they all will be hidden with original <tab>s wrapped in it, <tabs> didn't get any notification of new children so there is no way to configure it