### PR TITLE
removing the all the events bound to an element when it's unmounted

### DIFF
--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -66,7 +66,9 @@ function Tag(impl, conf) {
     if (p) {
       p.removeChild(el)
       self.trigger('unmount')
-      parent && parent.off('update', self.update)
+      parent && parent.off('update', self.update).off('unmount', self.unmount)
+      // remove all the events bound to this element
+      self.off('*')
     }
   }
 


### PR DESCRIPTION
I am still optimizing the memory heap of riotjs. With this patch I get the following memory heap:
```
30.51 MiB 0 ms
75.44 MiB 731 ms
88.78 MiB 695 ms
102.20 MiB 678 ms
115.39 MiB 732 ms
55.44 MiB 1342 ms <-- clean
68.59 MiB 720 ms
81.35 MiB 699 ms
106.91 MiB 699 ms
119.85 MiB 725 ms
132.81 MiB 776 ms
145.77 MiB 756 ms
158.36 MiB 761 ms
51.08 MiB 1080 ms <-- clean
63.90 MiB 807 ms 
```
It means that finally the life cycle of the riots views starts to be cleaned from the heap
With riotjs 2.0.9 that's the memory heap still keeps growing:
```
30.53 MiB 0 ms
75.64 MiB 751 ms
89.12 MiB 778 ms
102.63 MiB 958 ms
115.95 MiB 711 ms
110.39 MiB 909 ms
121.98 MiB 697 ms
134.46 MiB 671 ms
146.65 MiB 692 ms
171.64 MiB 663 ms
184.37 MiB 716 ms
196.74 MiB 713 ms
209.01 MiB 729 ms
233.90 MiB 707 ms
```