### PR TITLE
Style supports

### DIFF
--- a/doc/api/tags.md
+++ b/doc/api/tags.md
@@ -162,34 +162,38 @@ The above method and property names are reserved words for Riot tags. Don't use 
 ```
 
 
-### riot.tag(tagName, html, [constructor]) | #tag
+### riot.tag(tagName, html, [css], [constructor]) | #tag
 
 Creates a new custom tag "manually" without the compiler.
 
 - `tagName` the tag name
 - `html` is the layout with [expressions](/riotjs/guide/#expressions)
+- `css` is the style for the tag (optional)
 - `constructor` is the initialization function being called before the tag expressions are calculated and before the tag is mounted
 
 
 #### Example
 
 ``` js
-riot.tag('timer', '<p>Seconds Elapsed: { time }</p>', function (opts) {
-  this.time = opts.start || 0
-
-  this.tick = (function () {
-    this.update({
-        time: ++this.time
+riot.tag('timer',
+  '<p>Seconds Elapsed: { time }</p>',
+  'timer { display: block; border: 2px }',
+  function (opts) {
+    this.time = opts.start || 0
+  
+    this.tick = (function () {
+      this.update({
+          time: ++this.time
+      })
+    }).bind(this)
+  
+    var timer = setInterval(this.tick, 1000)
+  
+    this.on('unmount', function () {
+      clearInterval(timer)
     })
-  }).bind(this)
 
-  var timer = setInterval(this.tick, 1000)
-
-  this.on('unmount', function () {
-    clearInterval(timer)
   })
-
-})
 ```
 
 See [timer demo](http://jsfiddle.net/gnumanth/h9kuozp5/) and [riot.tag](/riotjs/api/#tag) API docs for more details and *limitations*.

--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -124,6 +124,26 @@ Currently available options are "coffeescript", "typescript", "es6" and "none". 
 See [pre processors](/riotjs/compiler.html#pre-processors) for more details.
 
 
+### Tag styling
+
+You can put `<style>` tag inside. Riot.js automatically take it out and inject it into `<head>`.
+
+```html
+<todo>
+
+  <!-- layout -->
+  <h3>{ opts.title }</h3>
+  
+  <style>
+    todo { display: block }
+    todo h3 { font-size: 120% }
+    /** other awesome stylings **/
+  </style>
+  
+</todo>
+```
+
+
 ## Mounting
 
 Once a tag is created you can mount it on the page as follows:

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -41,6 +41,7 @@
       // (tagname) (html) (javascript) endtag
       CUSTOM_TAG = /^<([\w\-]+)>([^\x00]*[\w\-\/}]>$)?([^\x00]*?)^<\/\1>/gim,
       SCRIPT = /<script(\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/script>/gm,
+      STYLE = /<style(\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/style>/gm,
       HTML_COMMENT = /<!--.*?-->/g,
       CLOSED_TAG = /<([\w\-]+)([^>]*)\/\s*>/g,
       LINE_COMMENT = /^\s*\/\/.*$/gm,
@@ -184,8 +185,17 @@
     return parser(html)
   }
 
-  function mktag(name, html, js) {
-    return 'riot.tag(\'' +name+ '\', \'' + html + '\', function(opts) {' + js + '\n});'
+  function compileCSS(style, styleType) {
+    //TODO: compile LESS, Sass, ...etc.
+
+    style = style.replace(/\s+/g, ' ')
+    style = style.trim()
+    style = style.replace(/'/g, "\\'")
+    return style
+  }
+
+  function mktag(name, html, css, js) {
+    return 'riot.tag(\'' + name + '\', \'' + html + '\'' + (css ? ', \'' + css + '\'' : '') + ', function(opts) {' + js + '\n});'
   }
 
   function compile(src, opts) {
@@ -213,7 +223,17 @@
         })
       }
 
-      return mktag(tagName, compileHTML(html, opts, type), compileJS(js, opts, type))
+      // styles in <style> tag
+      var style = ''
+      var styleType = 'css'
+
+      html = html.replace(STYLE, function(_, fullType, _type, _style) {
+        if (_type) styleType = _type.replace('text/', '')
+        style = _style
+        return ''
+      })
+
+      return mktag(tagName, compileHTML(html, opts, type), compileCSS(style, styleType), compileJS(js, opts, type))
 
     })
 

--- a/lib/tag/vdom.js
+++ b/lib/tag/vdom.js
@@ -8,8 +8,21 @@ var virtual_dom = [],
     tag_impl = {},
     expr_begin
 
-riot.tag = function(name, html, fn) {
+function injectStyle(css) {
+  var node = document.createElement('style'),
+      head = document.head
+
+  node.innerHTML = css
+  head.appendChild(node)
+}
+
+riot.tag = function(name, html, css, fn) {
   expr_begin = expr_begin || (riot.settings.brackets || '{ }').split(' ')[0]
+  if (typeof css == 'function') {
+    fn = css
+  } else if (css) {
+    injectStyle(css)
+  }
   tag_impl[name] = { name: name, tmpl: html, fn: fn }
 }
 

--- a/test/compiler/js/style.js
+++ b/test/compiler/js/style.js
@@ -1,0 +1,8 @@
+riot.tag('kids', '<h3>{ opts.title }</h3>', 'style-test { display: block; border: 2px }', function(opts) {
+
+  this.foo = function() {
+
+    this.update()
+  }.bind(this);
+
+});

--- a/test/compiler/style.tag
+++ b/test/compiler/style.tag
@@ -1,0 +1,16 @@
+
+<style-test>
+
+  <h3>{ opts.title }</h3>
+
+  <style>
+    style-test { display: block; border: 2px }
+  </style>
+
+  <script>
+    foo () {
+
+    }
+  </script>
+
+</style-test>

--- a/test/compiler/suite.js
+++ b/test/compiler/suite.js
@@ -71,6 +71,7 @@ function testFiles(opts) {
   test('test', { type: 'es6' })
   test('test.jade', { template: 'jade' })
   test('slide.jade', { template: 'jade' })
+  test('style', {})
 
 }
 


### PR DESCRIPTION
Take out styles from .tag file, then inject style into HTML. See #345 

This PR is a first step to support CSS preprocessors like LESS, Sass, ...etc. (not included yet)

Including:

- `<style>...</style>` extraction from `.tag` file
- API Change: `riot.tag(name, html, [css], [fn])` - `css` is optional to keep backward-compatibility

Background:

- Demands for LESS, Sass, Autoprefixer ...etc
- Multi-`<style>`-problem: If putting `<style>` in `.tag` file, it'll repeatedly appear in DOM