### PR TITLE
Add babel for ES6 compilation

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -84,7 +84,17 @@
   }
 
   function es6(js) {
-    return require('6to5').transform(js, { blacklist: ['useStrict'] }).code
+    var library
+    try {
+      library = require('babel')
+    } catch (noBabel) {
+      try {
+        library = require('6to5')
+      } catch (no6to5) {
+        throw new Error('Cannot find module babel or 6to5')
+      }
+    }
+    return library.transform(js, { blacklist: ['useStrict'] }).code
   }
 
   function typescript(js) {

--- a/compiler.js
+++ b/compiler.js
@@ -84,17 +84,7 @@
   }
 
   function es6(js) {
-    var library
-    try {
-      library = require('babel')
-    } catch (noBabel) {
-      try {
-        library = require('6to5')
-      } catch (no6to5) {
-        throw new Error('Cannot find module babel or 6to5')
-      }
-    }
-    return library.transform(js, { blacklist: ['useStrict'] }).code
+    return require('babel').transform(js, { blacklist: ['useStrict'] }).code
   }
 
   function typescript(js) {


### PR DESCRIPTION
Here there, [6to5 has changed it's name to "babel"](https://babeljs.io/).

I've tried to add some backwards compatibility, but I don't understand how to run your tests.