### PR TITLE
tag require extension

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -33,6 +33,7 @@ var methods = {
       '  --template      HTML pre-processor. Built-in suupport for: jade',
       '  --brackets      Change brackets used for expressions. Defaults to { }',
       '  --expr          Run expressions trough parser defined with --type',
+      '  --cjs           Generate CommonJS modules. Defaults to false',
       '  --ext           Change tag file extension. Defaults to .tag',
       '',
       'Build a single .tag file:',
@@ -165,7 +166,8 @@ function cli() {
       template: args.template,
       type: args.type,
       brackets: args.brackets,
-      expr: args.expr
+      expr: args.expr,
+      cjs: args.cjs
     },
     ext: args.ext,
     from: args._.shift(),

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -33,7 +33,6 @@ var methods = {
       '  --template      HTML pre-processor. Built-in suupport for: jade',
       '  --brackets      Change brackets used for expressions. Defaults to { }',
       '  --expr          Run expressions trough parser defined with --type',
-      '  --cjs           Generate CommonJS modules. Defaults to false',
       '  --ext           Change tag file extension. Defaults to .tag',
       '',
       'Build a single .tag file:',
@@ -166,8 +165,7 @@ function cli() {
       template: args.template,
       type: args.type,
       brackets: args.brackets,
-      expr: args.expr,
-      cjs: args.cjs
+      expr: args.expr
     },
     ext: args.ext,
     from: args._.shift(),

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -187,7 +187,17 @@
     return style
   }
 
-  function mktag(name, html, css, js) {
+  function mktag(name, html, css, js, opts) {
+    if (opts.cjs) {
+      return 'module.exports = {\n' +
+        '\tname: \'' + name + '\',\n' +
+        '\ttmpl: \'' + html + '\',\n' +
+        '\tcss: \'' + css + '\',\n' +
+        '\tfn: function(opts) {' +
+          js +
+        '\n\t}' +
+      '\n}'
+    }
     return 'riot.tag(\''
       + name + '\', \''
       + html + '\''
@@ -236,7 +246,8 @@
         tagName,
         compileHTML(html, opts, type),
         compileCSS(style, styleType),
-        compileJS(js, opts, type)
+        compileJS(js, opts, type),
+        opts
       )
 
     })

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -187,17 +187,7 @@
     return style
   }
 
-  function mktag(name, html, css, js, opts) {
-    if (opts.cjs) {
-      return 'module.exports = {\n' +
-        '\tname: \'' + name + '\',\n' +
-        '\ttmpl: \'' + html + '\',\n' +
-        '\tcss: \'' + css + '\',\n' +
-        '\tfn: function(opts) {' +
-          js +
-        '\n\t}' +
-      '\n}'
-    }
+  function mktag(name, html, css, js) {
     return 'riot.tag(\''
       + name + '\', \''
       + html + '\''
@@ -246,8 +236,7 @@
         tagName,
         compileHTML(html, opts, type),
         compileCSS(style, styleType),
-        compileJS(js, opts, type),
-        opts
+        compileJS(js, opts, type)
       )
 
     })
@@ -258,10 +247,9 @@
   // io.js (node)
   if (is_server) {
     this.riot = require(process.env.RIOT || '../riot')
-    return module.exports = {
-      html: compileHTML,
-      compile: compile
-    }
+    this.riot.html = compileHTML
+    this.riot.compile = compile
+    return module.exports = this.riot
   }
 
   // browsers

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -247,9 +247,10 @@
   // io.js (node)
   if (is_server) {
     this.riot = require(process.env.RIOT || '../riot')
-    this.riot.html = compileHTML
-    this.riot.compile = compile
-    return module.exports = this.riot
+    return module.exports = {
+      html: compileHTML,
+      compile: compile
+    }
   }
 
   // browsers

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,14 @@
+var fs = require('fs')
+
+var riot = module.exports = require('./compiler')
+
+var registered = false
+riot.register = function(extension) {
+  if (!registered) {
+    require.extensions[extension || '.tag'] = function(module, filename) {
+      var src = riot.compile(fs.readFileSync(filename, 'utf8'), { cjs: true })
+      module._compile(src, filename)
+    }
+  }
+  return riot
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
 var fs = require('fs')
+var compiler = require('./compiler')
 
-var riot = module.exports = require('./compiler')
+var riot = module.exports = require(process.env.RIOT || '../riot')
 
 require.extensions['.tag'] = function(module, filename) {
-  var src = riot.compile(fs.readFileSync(filename, 'utf8'))
+  var src = compiler.compile(fs.readFileSync(filename, 'utf8'))
   module._compile(src, filename)
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,13 +2,7 @@ var fs = require('fs')
 
 var riot = module.exports = require('./compiler')
 
-var registered = false
-riot.register = function(extension) {
-  if (!registered) {
-    require.extensions[extension || '.tag'] = function(module, filename) {
-      var src = riot.compile(fs.readFileSync(filename, 'utf8'), { cjs: true })
-      module._compile(src, filename)
-    }
-  }
-  return riot
+require.extensions['.tag'] = function(module, filename) {
+  var src = riot.compile(fs.readFileSync(filename, 'utf8'))
+  module._compile(src, filename)
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "jscs": "^1.11.3",
     "jsdom": "^3.1.1",
     "jshint": "latest",
-    "tape": "^3.5.0",
     "uglify-js": "latest"
   },
   "preferGlobal": true,
@@ -58,9 +57,6 @@
   },
   "main": "lib/index.js",
   "browser": "riot.js",
-  "scripts": {
-    "test": "node test/commonjs.js"
-  },
   "spm": {
     "main": "riot.js",
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jscs": "^1.11.3",
     "jsdom": "^3.1.1",
     "jshint": "latest",
+    "tape": "^3.5.0",
     "uglify-js": "latest"
   },
   "preferGlobal": true,
@@ -55,8 +56,11 @@
   "bin": {
     "riot": "lib/cli.js"
   },
-  "main": "lib/compiler.js",
+  "main": "lib/index.js",
   "browser": "riot.js",
+  "scripts": {
+    "test": "node test/commonjs.js"
+  },
   "spm": {
     "main": "riot.js",
     "ignore": [

--- a/test/commonjs.js
+++ b/test/commonjs.js
@@ -1,12 +1,7 @@
 var test = require('tape')
-
-var riot = require('..').register()
-var timer = require('./tag/timer.tag')
+var riot = require('..')
 
 test('riot require extension test', function(t) {
-  t.plan(4)
-  t.equal(timer.name, 'timer', 'tag name should be ok')
-  t.equal(timer.tmpl, '<p>Seconds Elapsed: { time }</p>', 'tag html should be ok')
-  t.equal(timer.css, '', 'tag css should be empty')
-  t.equal(typeof timer.fn, 'function', 'tag `fn` should be a function')
+  t.plan(1)
+  t.ok(require('./tag/timer.tag'), 'requiring tag file')
 })

--- a/test/commonjs.js
+++ b/test/commonjs.js
@@ -1,7 +1,6 @@
-var test = require('tape')
+var assert = require('assert')
+
 var riot = require('..')
 
-test('riot require extension test', function(t) {
-  t.plan(1)
-  t.ok(require('./tag/timer.tag'), 'requiring tag file')
-})
+assert.ok(require('./tag/timer.tag'))
+assert.equal(riot.render('timer', { start: 10 }), '<p>Seconds Elapsed: 10</p>')

--- a/test/commonjs.js
+++ b/test/commonjs.js
@@ -1,0 +1,12 @@
+var test = require('tape')
+
+var riot = require('..').register()
+var timer = require('./tag/timer.tag')
+
+test('riot require extension test', function(t) {
+  t.plan(4)
+  t.equal(timer.name, 'timer', 'tag name should be ok')
+  t.equal(timer.tmpl, '<p>Seconds Elapsed: { time }</p>', 'tag html should be ok')
+  t.equal(timer.css, '', 'tag css should be empty')
+  t.equal(typeof timer.fn, 'function', 'tag `fn` should be a function')
+})

--- a/test/commonjs.js
+++ b/test/commonjs.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 
+process.env.RIOT = '../dist/riot/riot'
 var riot = require('..')
 
 assert.ok(require('./tag/timer.tag'))
-assert.equal(riot.render('timer', { start: 10 }), '<p>Seconds Elapsed: 10</p>')


### PR DESCRIPTION
Added feature to allow registering `require` extension to support .tag files.

```
var riot = require('riot')
riot.register()

var timer = require('./timer.tag')
console.log(timer.tmpl) // <p>Seconds Elapsed: { time }</p>
```