### PR TITLE
Replace jsHint and JsCs with ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+lib/wrap
+test/ie8

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,218 @@
+env:
+
+    ###########################################################################
+    #                                                                         #
+    #   ENVIRONMENT: if you write code that will be executed in one of the    #
+    #   following environments, the value for that environment should be      #
+    #   set to true.                                                          #
+    #                                                                         #
+    ###########################################################################
+
+    browser: true
+
+globals:
+
+    ###########################################################################
+    #                                                                         #
+    #   GLOBALS: ESLint will assume the following variables are declared      #
+    #   globally; other variables will require explicit declaration.          #
+    #                                                                         #
+    ###########################################################################
+
+    require: true
+
+rules:
+
+    ###########################################################################
+    #                                                                         #
+    #   POSSIBLE ERRORS: these rules point out areas where you might have     #
+    #   made mistakes.                                                        #
+    #                                                                         #
+    ###########################################################################
+
+    no-comma-dangle: 1         # disallow trailing commas in object literals
+    no-cond-assign: 0          # disallow assignment in conditional expressions
+    no-console: 0              # disallow use of console
+    no-constant-condition: 2   # disallow use of constant expressions in conditions
+    no-control-regex: 2        # disallow control characters in regular expressions
+    no-debugger: 2             # disallow use of debugger
+    no-dupe-keys: 2            # disallow duplicate keys when creating object literals
+    no-empty: 2                # disallow empty statements
+    no-empty-class: 2          # disallow the use of empty character classes in regular expressions
+    no-ex-assign: 2            # disallow assigning to the exception in a catch block
+    no-extra-boolean-cast: 2   # disallow double-negation boolean casts in a boolean context
+    no-extra-parens: 0         # disallow unnecessary parentheses
+    no-extra-semi: 0           # disallow unnecessary semicolons
+    no-func-assign: 0          # disallow overwriting functions written as function declarations
+    no-inner-declarations: 1   # disallow function or variable declarations in nested blocks
+    no-invalid-regexp: 2       # disallow invalid regular expression strings in the RegExp
+                               #    constructor
+    no-irregular-whitespace: 2 # disallow irregular whitespace outside of strings and comments
+    no-negated-in-lhs: 2       # disallow negation of the left operand of an in expression
+    no-obj-calls: 2            # disallow the use of object properties of the global object (Math
+                               #    and JSON) as functions
+    no-regex-spaces: 1         # disallow multiple spaces in a regular expression literal
+    no-reserved-keys: 0        # disallow reserved words being used as object literal keys
+    no-sparse-arrays: 2        # disallow sparse arrays
+    no-unreachable: 2          # disallow unreachable statements after a return, throw, continue,
+                               #    or break statement
+    use-isnan: 2               # disallow comparisons with the value NaN
+    valid-jsdoc:               # ensure JSDoc comments are valid
+        [1, { "prefer": { "return": "returns" }, "requireReturn": false }]
+    valid-typeof: 2            # ensure that the results of typeof are compared against a
+                               #    valid string
+
+    ###########################################################################
+    #                                                                         #
+    #   BEST PRACTICES: these rules are designed to prevent you from making   #
+    #   mistakes. They either prescribe a better way of doing something or    #
+    #   help you avoid pitfalls.                                              #
+    #                                                                         #
+    ###########################################################################
+
+    block-scoped-var: 0       # treat var statements as if they were block scoped
+    complexity: [1, 250]      # specify the maximum cyclomatic complexity allowed in a program
+    consistent-return: 0      # require return statements to either always or never specify values
+    curly: 0                  # specify curly brace conventions for all control
+                              #     statements
+    default-case: 2           # require default case in switch statements
+    dot-notation: 1           # encourages use of dot notation whenever possible
+    eqeqeq: o                 # require the use of === and !==
+    guard-for-in: 1           # make sure for-in loops have an if statement
+    no-alert: 2               # disallow the use of alert, confirm, and prompt
+    no-caller: 2              # disallow use of arguments.caller or arguments.callee
+    no-div-regex: 0           # disallow division operators explicitly at beginning of regular
+                              #    expression
+    no-else-return: 0         # disallow else after a return in an if
+    no-empty-label: 2         # disallow use of labels for anything other then loops and switches
+    no-eq-null: 0             # disallow comparisons to null without a type-checking operator
+    no-eval: 2                # disallow use of eval()
+    no-extend-native: 2       # disallow adding to native types
+    no-extra-bind: 2          # disallow unnecessary function binding
+    no-fallthrough: 2         # disallow fallthrough of case statements
+    no-floating-decimal: 2    # disallow the use of leading or trailing decimal points in numeric
+                              #    literals
+    no-implied-eval: 2        # disallow use of eval()-like methods
+    no-iterator: 2            # disallow usage of __iterator__ property
+    no-labels: 2              # disallow use of labeled statements
+    no-lone-blocks: 2         # disallow unnecessary nested blocks
+    no-loop-func: 0           # disallow creation of functions within loops
+    no-multi-spaces: 0        # disallow use of multiple spaces
+    no-multi-str: 2           # disallow use of multiline strings
+    no-native-reassign: 2     # disallow reassignments of native objects
+    no-new: 2                 # disallow use of new operator when not part of the assignment or
+                              #    comparison
+    no-new-func: 0            # disallow use of new operator for Function object
+    no-new-wrappers: 2        # disallows creating new instances of String,Number, and Boolean
+    no-octal: 2               # disallow use of octal literals
+    no-octal-escape: 2        # disallow use of octal escape sequences in string literals, such as
+                              #    `var foo = "Copyright \251"`
+    no-process-env: 0         # disallow use of process.env
+    no-proto: 2               # disallow usage of __proto__ property
+    no-redeclare: 1           # disallow declaring the same variable more then once
+    no-return-assign: 0       # disallow use of assignment in return statement
+    no-script-url: 2          # disallow use of javascript urls.
+    no-self-compare: 2        # disallow comparisons where both sides are exactly the same
+    no-sequences: 2           # disallow use of comma operator
+    no-unused-expressions: 0  # disallow usage of expressions in statement position
+    no-void: 2                # disallow use of void operator
+    no-warning-comments: 0    # disallow usage of configurable warning terms in comments - e.g.
+                              #     TODO or FIXME
+    no-with: 2                # disallow use of the with statement
+    radix: 2                  # require use of the second argument for parseInt()
+    vars-on-top: 0            # requires to declare all vars on top of their containing scope
+    wrap-iife: [2, "inside"]  # require immediate function invocation to be wrapped in parentheses
+    yoda: "never"             # require or disallow Yoda conditions
+
+    ###########################################################################
+    #                                                                         #
+    #   STRICT MODE: these rules relate to using strict mode.                 #
+    #                                                                         #
+    ###########################################################################
+
+    strict: [2, "never"]           # require that all functions are run in strict mode
+
+    ###########################################################################
+    #                                                                         #
+    #   VARIABLES: these rules have to do with variable declarations.         #
+    #                                                                         #
+    ###########################################################################
+
+    no-catch-shadow: 2             # disallow the catch clause parameter name being the same as a
+                                   #    variable in the outer scope
+    no-delete-var: 2               # disallow deletion of variables
+    no-label-var: 2                # disallow labels that share a name with a variable
+    no-shadow: 0                   # disallow declaration of variables already declared in the
+                                   #    outer scope
+    no-shadow-restricted-names: 2  # disallow shadowing of names such as arguments
+    no-undef: 0                    # disallow use of undeclared variables unless mentioned in a
+                                   #    /*global */ block
+    no-undef-init: 2               # disallow use of undefined when initializing variables
+    no-undefined: 0                # disallow use of undefined variable
+    no-unused-vars: 0              # disallow declaration of variables that are not used in the code
+    no-use-before-define: 0        # disallow use of variables before they are defined
+
+    ###########################################################################
+    #                                                                         #
+    #   NODE: these rules relate to functionality provided in Node.js.        #
+    #                                                                         #
+    ###########################################################################
+
+    handle-callback-err: 0        # enforces error handling in callbacks
+    no-mixed-requires: 0          # disallow mixing regular variable and require declarations
+    no-new-require: 2             # disallow use of new operator with the require function
+    no-path-concat: 2             # disallow string concatenation with __dirname and __filename
+    no-process-exit: 0            # disallow process.exit()
+    no-restricted-modules: 0      # restrict usage of specified node modules
+    no-sync: 0                    # disallow use of synchronous methods
+
+    ###########################################################################
+    #                                                                         #
+    #   STYLISTIC ISSUES: these rules are purely matters of style and,        #
+    #   while valueable to enforce consistently across a project, are         #
+    #   quite subjective.                                                     #
+    #                                                                         #
+    ###########################################################################
+
+    indent: [2, 2]                 # Set a specific tab width
+    brace-style: 0                 # enforce one true brace style
+    camelcase: 0                   # require camel case names
+    comma-spacing: 0               # enforce spacing before and after comma
+    comma-style: 2                 # enforce one true comma style
+    consistent-this: 0             # enforces consistent naming when capturing the current execution context
+    eol-last: 0                    # enforce newline at the end of file, with no multiple empty lines
+    func-names: 0                  # require function expressions to have a name
+    func-style: 0                  # enforces use of function declarations or expressions
+    key-spacing: 2                 # enforces spacing between keys and values in object literal properties
+    max-nested-callbacks: [2, 4]   # specify the maximum depth callbacks can be nested
+    new-cap: 0                     # require a capital letter for constructors
+    new-parens: 2                  # disallow the omission of parentheses when invoking a constructor with no arguments
+    no-array-constructor: 2        # disallow use of the Array constructor
+    no-lonely-if: 0                # disallow if as the only statement in an else block
+    no-mixed-spaces-and-tabs: 2    # disallow mixed spaces and tabs for indentation
+    no-nested-ternary: 0           # disallow nested ternary expressions
+    no-new-object: 1               # disallow use of the Object constructor
+    no-space-before-semi: 0        # disallow space before semicolon
+    no-spaced-func: 2              # disallow space between function identifier and application
+    no-ternary: 0                  # disallow the use of ternary operators
+
+    no-trailing-spaces: 2          # disallow trailing whitespace at the end of lines
+    no-multiple-empty-lines: 0     # disallow multiple empty lines
+    no-underscore-dangle: 0        # disallow dangling underscores in identifiers
+    no-wrap-func: 2                # disallow wrapping of non-IIFE statements in parens
+    one-var: 0                     # allow just one var statement per function
+    padded-blocks: 0               # enforce padding within blocks
+    quotes:                        # specify whether double or single quotes should be used
+        [1, "single", "avoid-escape"]
+    quote-props: 0                 # require quotes around object literal property names
+    semi: [2, "never"]             # require or disallow use of semicolons instead of ASI
+    sort-vars: 0                   # sort variables within the same declaration block
+    space-after-keywords: "always" # require a space after certain keywords
+    space-before-blocks: 2         # require or disallow space before blocks
+    space-in-brackets: 0           # require or disallow spaces inside brackets
+    space-in-parens: 0             # require or disallow spaces inside parentheses
+    space-infix-ops: 0             # require spaces around operators
+    space-return-throw-case: 2     # require a space after return, throw, and case
+    spaced-line-comment: 0         # require or disallow a space immediately following
+                                   #    the // in a line comment
+    wrap-regex: 0                  # require regex literals to be wrapped in parentheses

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,0 @@
-{
-    "validateIndentation": 2,
-    "excludeFiles": ["test/ie8/**","lib/wrap/*.js"]
-}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,0 @@
-lib/wrap/*.js
-test/ie8/*.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,9 +1,0 @@
-{
-  "expr": true,
-  "asi": true,
-  "laxbreak": true,
-  "eqnull": true,
-  "evil": true,
-  "-W093": true,
-  "-W067": true
-}

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,10 @@ WATCH = "\
 			require('shelljs').exec(cmd) 										  \
 		})"
 
-
-jshint:
-	# check code quality
-	@ ./node_modules/jshint/bin/jshint lib test
-
-jscs:
+eslint:
 	# check code style
-	@ ./node_modules/jscs/bin/jscs lib test
+	# TODO: Get ./test up to standards and add back
+	@ ./node_modules/eslint/bin/eslint.js -c ./.eslintrc lib
 
 raw:
 	@ mkdir -p $(DIST)
@@ -26,7 +22,7 @@ raw:
 	@ cat $(DIST)riot.js $(DIST)compiler.js > $(DIST)riot+compiler.js
 	@ cat lib/wrap/suffix.js | tee -a $(DIST)riot.js $(DIST)riot+compiler.js > /dev/null
 
-riot: jshint jscs raw
+riot: eslint raw
 
 min: riot
 	# minify riot

--- a/package.json
+++ b/package.json
@@ -37,9 +37,8 @@
     "shelljs": "~0.3.0"
   },
   "devDependencies": {
-    "jscs": "^1.11.3",
+    "eslint": "^0.14.1",
     "jsdom": "^3.1.1",
-    "jshint": "latest",
     "uglify-js": "latest"
   },
   "preferGlobal": true,


### PR DESCRIPTION
#### What does this PR Change
This PR converts jsHint+JsCs -> esLint.

#### Why
In my current position I do a LOT of code reviews - somewhere between 35-75/week. What I've learned from managing a big project with lots of contributors is that the more you can enforce programmatically the less work you have to do in reviews and docs maintenance. There is a lot of support behind this and projects like [HoundCI](https://houndci.com/) are trying to make this less painful. After all a good codebase is one that's so consistent that you can't even tell who wrote what line :)

#### What's Next
* esLint (like JsHint or JsCs) should be hooked into CI
* Remove the style section from CONTRIBUTING.md in favor of automation. 
* This PR revealed lots of style inconsistencies (I had to disable checking of the .test/ for the moment mainly for use of `;` and `"`) as well as a number of potential bugs and violations of best practices. A number of rules are turned off at the moment to prevent a huge diff but if this PR is approved we can slowly turn more on as the project converges on styles and conventions.

#### Why include that giant esLint file?
This file is a complete list of all available options and should serve as a living style guide. And in the end Explicit > Implicit