### PR TITLE
Fix `SET_ATTR` regexp

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -25,7 +25,7 @@
 
   var LINE_TAG = /^<([\w\-]+)>(.*)<\/\1>/gim,
       QUOTE = /=({[^}]+})([\s\/\>])/g,
-      SET_ATTR = /([\w\-]+)=["']([^"']+)["']/g,
+      SET_ATTR = /([\w\-]+)=(["'])([^\2]+)\2/g,
       EXPR = /{\s*([^}]+)\s*}/g,
       // (tagname) (html) (javascript) endtag
       CUSTOM_TAG = /^<([\w\-]+)>([^\x00]*[\w\/}]>$)?([^\x00]*?)^<\/\1>/gim,
@@ -52,7 +52,7 @@
     html = html.replace(brackets(QUOTE), '="$1"$2')
 
     // alter special attribute names
-    html = html.replace(SET_ATTR, function(full, name, expr) {
+    html = html.replace(SET_ATTR, function(full, name, _, expr) {
       if (expr.indexOf(brackets(0)) >= 0) {
         name = name.toLowerCase()
 


### PR DESCRIPTION
A quick fix for the bug introduced at https://github.com/muut/riotjs/commit/63ebc6b5f9b925a9025bd8baeed773f0a9b8a21d