### PR TITLE
Fix: greedy attribute name substitution in 2.0.11

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -7,7 +7,8 @@
     'pauseonexit,readonly,required,reversed,scoped,seamless,selected,sortable,spellcheck,translate,truespeed,'+
     'typemustmatch,visible').split(',')
 
-  var RIOT_ATTR = ('style,src').split(',')
+  // 'd' describes the SVG <path>, Chrome gives error if the value is not valid format (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d)
+  var PREFIX_ATTR = ('style,src,d').split(',')
 
   var VOID_TAGS = 'area,base,br,col,command,embed,hr,img,input,keygen,link,meta,param,source,track,wbr'.split(',')
 
@@ -56,8 +57,8 @@
       if (expr.indexOf(brackets(0)) >= 0) {
         name = name.toLowerCase()
 
-        // <img src> --> <img riot-src>
-        if (RIOT_ATTR.indexOf(name) >= 0) name = 'riot-' + name
+        // some attributes needs 'riot-' prefix: <img src> --> <img riot-src>, <path d> --> <path riot-d>
+        if (PREFIX_ATTR.indexOf(name) >= 0) name = 'riot-' + name
 
         // IE8 looses boolean attr values: `checked={ expr }` --> `__checked={ expr }`
         else if (BOOL_ATTR.indexOf(name) >= 0) name = '__' + name

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -7,7 +7,7 @@
     'pauseonexit,readonly,required,reversed,scoped,seamless,selected,sortable,spellcheck,translate,truespeed,'+
     'typemustmatch,visible').split(',')
 
-  var RIOT_ATTR = ('style,src,d').split(',')
+  var RIOT_ATTR = ('style,src').split(',')
 
   var VOID_TAGS = 'area,base,br,col,command,embed,hr,img,input,keygen,link,meta,param,source,track,wbr'.split(',')
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -7,6 +7,8 @@
     'pauseonexit,readonly,required,reversed,scoped,seamless,selected,sortable,spellcheck,translate,truespeed,'+
     'typemustmatch,visible').split(',')
 
+  var RIOT_ATTR = ('style,src,d').split(',')
+
   var VOID_TAGS = 'area,base,br,col,command,embed,hr,img,input,keygen,link,meta,param,source,track,wbr'.split(',')
 
   var HTML_PARSERS = {
@@ -57,7 +59,7 @@
         name = name.toLowerCase()
 
         // <img src> --> <img riot-src>
-        if (/style|src/.test(name)) name = 'riot-' + name
+        if (RIOT_ATTR.indexOf(name) >= 0) name = 'riot-' + name
 
         // IE8 looses boolean attr values: `checked={ expr }` --> `__checked={ expr }`
         else if (BOOL_ATTR.indexOf(name) >= 0) name = '__' + name

--- a/test/specs/tmpl.js
+++ b/test/specs/tmpl.js
@@ -101,7 +101,8 @@ describe('Tmpl', function() {
 
     window.globalVar = 5
     expect(render('{ globalVar }')).to.equal(window.globalVar)
-    expect(render('{ location.href.split(".").pop() }')).to.equal('html')
+    // breaks the tests, location is "about:blank"
+    // expect(render('{ location.href.split(".").pop() }')).to.equal('html')
 
     data.esc = '\'\n\\'
     expect(render('{ esc }')).to.equal(data.esc)


### PR DESCRIPTION
Attribute name substitution (`riot-attr={expr}` -> `attr="value"`) is broken in the 2.0.11 compiler for `style` and `src`.
`riot-src={expr}` is compiled into `riot-riot-src={expr}` and rendered as `riot-src="value"` on update, while any other `riot-attr={expr}` is left as is and rendered correctly as `attr="value"` on update.

This PR makes `riot-src` and `riot-style` behave as any other `riot-attr`.


<del>Also commented out a recently uncommented out test in test/specs/tmpl.js that was failing in dev before this commit.
When the test is running, `location.href` is "about:blank", so `location.href.split(".").pop()` can never be "html".</del>
Merged with riotjs/dev to solve conflicts after the tests where fixed in riotjs/dev.