### PR TITLE
Scoped CSS

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -39,8 +39,7 @@ The equality operator is good when you know how it works. We do this for example
 This causes `0` and `false` to be printed but `null` and `undefined` are printed as an empty string. Exactly what we want!
 
 
-### Can I use   // named elements
-`style` tags in a .tag file?
+### Can I use `style` tags in a .tag file?
 Yes. You can use CSS normally inside a tag. The web component standard also has a mechanism of encapsulating of CSS. However, it's unlikely that this improves the overall manageability of your CSS.
 
 

--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -131,8 +131,7 @@ See [pre processors](/riotjs/compiler.html#pre-processors) for more details.
 
 ### Tag styling
 
-You can put   // named elements
-`style` tag inside. Riot.js automatically take it out and inject it into `<head>`.
+You can put `style` tag inside. Riot.js automatically take it out and inject it into `<head>`.
 
 ```html
 <todo>
@@ -143,6 +142,23 @@ You can put   // named elements
   <style>
     todo { display: block }
     todo h3 { font-size: 120% }
+    /** other awesome stylings **/
+  </style>
+
+</todo>
+```
+
+**Scoped CSS** is also available. The example below is equivalent to the first one.
+
+```html
+<todo>
+
+  <!-- layout -->
+  <h3>{ opts.title }</h3>
+
+  <style scoped>
+    :scope { display: block }
+    h3 { font-size: 120% }
     /** other awesome stylings **/
   </style>
 
@@ -365,8 +381,7 @@ When using [pre-compiler](compiler.html#pre-compilation) you'll have to set `bra
 
 ### Etc
 
-Expressions inside   // named elements
-`style` tags are ignored.
+Expressions inside `style` tags are ignored.
 
 
 ### Render unescaped HTML

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -30,7 +30,9 @@
       // (tagname) (html) (javascript) endtag
       CUSTOM_TAG = /^<([\w\-]+)>([^\x00]*[\w\/}]>$)?([^\x00]*?)^<\/\1>/gim,
       SCRIPT = /<script(\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/script>/gm,
-      STYLE = /<style(\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/style>/gm,
+      STYLE = /<style(\s+type=['"]?([^>'"]+)['"]?|\s+scoped)?>([^\x00]*?)<\/style>/gm,
+      CSS_SELECTOR = /(^|\}|\{)\s*([^\{\}]+)\s*(?=\{)/g,
+      CSS_COMMENT = /\/\*[^\x00]*?\*\//gm,
       HTML_COMMENT = /<!--.*?-->/g,
       CLOSED_TAG = /<([\w\-]+)([^>]*)\/\s*>/g,
       LINE_COMMENT = /^\s*\/\/.*$/gm,
@@ -164,6 +166,13 @@
 
   }
 
+  function scopedCSS (tag, style) {
+    return style.replace(CSS_COMMENT, '').replace(CSS_SELECTOR, function (m, p1, p2) {
+      return p1 + ' ' + p2.split(/\s*,\s*/g).map(function(sel) {
+        return sel[0] == '@' ? sel : tag + ' ' + sel.replace(/:scope\s*/, '')
+      }).join(',')
+    }).trim()
+  }
 
   function compileJS(js, opts, type) {
     var parser = opts.parser || (type ? JS_PARSERS[type] : riotjs)
@@ -177,10 +186,9 @@
     return parser(html)
   }
 
-  function compileCSS(style, styleType) {
-    //TODO: compile LESS, Sass, ...etc.
-
-    return style.replace(/\s+/g, ' ').trim().replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+  function compileCSS(style, tag, type) {
+    if (type == 'scoped-css') style = scopedCSS(tag, style)
+    return style.replace(/\s+/g, ' ').replace(/\\/g, '\\\\').replace(/'/g, "\\'").trim()
   }
 
   function mktag(name, html, css, js) {
@@ -223,7 +231,8 @@
       var styleType = 'css'
 
       html = html.replace(STYLE, function(_, fullType, _type, _style) {
-        if (_type) styleType = _type.replace('text/', '')
+        if (fullType && 'scoped' == fullType.trim()) styleType = 'scoped-css'
+          else if (_type) styleType = _type.replace('text/', '')
         style = _style
         return ''
       })
@@ -231,7 +240,7 @@
       return mktag(
         tagName,
         compileHTML(html, opts, type),
-        compileCSS(style, styleType),
+        compileCSS(style, tagName, styleType),
         compileJS(js, opts, type)
       )
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -254,7 +254,8 @@
     this.riot = require(process.env.RIOT || '../riot')
     return module.exports = {
       html: compileHTML,
-      compile: compile
+      compile: compile,
+      style: compileCSS
     }
   }
 

--- a/test/compiler/style.scoped.tag
+++ b/test/compiler/style.scoped.tag
@@ -1,0 +1,51 @@
+
+<style-test>
+
+  <header>
+    <h1>{ title1 }</h1>
+    <h2>{ title2 }</h2>
+    <a class="button"><i class="twitter"></i> Twitter</a>
+  </header>
+  <h3 id="id">{ title3 }</h3>
+  <ul>
+    <li>Apple</li>
+    <li>Orange</li>
+  </ul>
+
+  <style scoped>
+    /* multi in a line */
+    h1 { font-size: 150% } #id { color: #f00 }
+    /* complex */
+    header a.button:hover { text-decoration: none }
+    /* comma separated */
+    h2, h3 { border-bottom: 1px solid #000 }
+    /* attr */
+    i[class=twitter] { background: #55ACEE }
+    /* backslash */
+    a:after { content: '\25BA' }
+    /* multi line */
+    header {
+      text-align: center;
+      background: rgba(0,0,0,.2);
+    }
+    /* root scope */
+    :scope { display: block }
+    /* root scope nested */
+    :scope > ul { padding: 0 }
+    /* font-face */
+    @font-face { font-family: 'FontAwesome' }
+    /* media query */
+    @media (min-width: 500px) {
+      header {
+        text-align: left;
+      }
+    }
+  </style>
+
+  <script>
+    this.title1 = 'This is an example with Scoped-CSS.'
+    this.title2 = 'KORE-WA-Scoped-CSS-NO-SAMPLE=DESU'
+    this.title3 = 'List of fruits'
+  </script>
+
+</style-test>

--- a/test/runner.js
+++ b/test/runner.js
@@ -19,6 +19,7 @@ describe('Riotjs tests', function() {
     require('./specs/tmpl')
     require('./specs/observable')
     require('./specs/route')
+    require('./specs/scoped-css')
 
   } else {
     mocha.run()

--- a/test/specs/scoped-css.js
+++ b/test/specs/scoped-css.js
@@ -4,47 +4,47 @@ describe('Scoped CSS', function() {
     return compiler.style(str, 'my-tag', 'scoped-css')
   }
 
-  it('should add my-tag to the simple selector', function() {
+  it('add my-tag to the simple selector', function() {
     expect(render('h1 { font-size: 150% }'))
         .to.equal('my-tag h1 { font-size: 150% }')
   })
-  it('should add my-tag to the multi selector in a line', function() {
+  it('add my-tag to the multi selector in a line', function() {
     expect(render('h1 { font-size: 150% } #id { color: #f00 }'))
         .to.equal('my-tag h1 { font-size: 150% } my-tag #id { color: #f00 }')
   })
-  it('should add my-tag to the complex selector', function() {
+  it('add my-tag to the complex selector', function() {
     expect(render('header a.button:hover { text-decoration: none }'))
         .to.equal('my-tag header a.button:hover { text-decoration: none }')
   })
-  it('should add my-tag to the comma-separated selector', function() {
+  it('add my-tag to the comma-separated selector', function() {
     expect(render('h2, h3 { border-bottom: 1px solid #000 }'))
         .to.equal('my-tag h2,my-tag h3 { border-bottom: 1px solid #000 }')
   })
-  it('should add my-tag to the attribute selector', function() {
+  it('add my-tag to the attribute selector', function() {
     expect(render('i[class=twitter] { background: #55ACEE }'))
         .to.equal('my-tag i[class=twitter] { background: #55ACEE }')
   })
-  it('should add my-tag to the selector with a backslash', function() {
+  it('add my-tag to the selector with a backslash', function() {
     expect(render('a:after { content: "\25BA" }'))
         .to.equal('my-tag a:after { content: "\25BA" }')
   })
-  it('should add my-tag to the selector with multi-line definitions', function() {
+  it('add my-tag to the selector with multi-line definitions', function() {
     expect(render('header {\n  text-align: center;\n  background: rgba(0,0,0,.2);\n}'))
         .to.equal('my-tag header { text-align: center; background: rgba(0,0,0,.2); }')
   })
-  it('should add my-tag to the root selector', function() {
+  it('add my-tag to the root selector', function() {
     expect(render(':scope { display: block }'))
         .to.equal('my-tag { display: block }')
   })
-  it('should add my-tag to the nested root selector', function() {
+  it('add my-tag to the nested root selector', function() {
     expect(render(':scope > ul { padding: 0 }'))
         .to.equal('my-tag > ul { padding: 0 }')
   })
-  it('should not add my-tag to @font-face', function() {
+  it('not add my-tag to @font-face', function() {
     expect(render('@font-face { font-family: "FontAwesome" }'))
         .to.equal('@font-face { font-family: "FontAwesome" }')
   })
-  it('should not add my-tag to @media, and should add it to the selector inside', function() {
+  it('not add my-tag to @media, and add it to the selector inside', function() {
     expect(render('@media (min-width: 500px) {\n  header {\n    text-align: left;\n  }\n}'))
         .to.equal('@media (min-width: 500px) { my-tag header { text-align: left; } }')
   })

--- a/test/specs/scoped-css.js
+++ b/test/specs/scoped-css.js
@@ -1,0 +1,52 @@
+describe('Scoped CSS', function() {
+
+  function render(str) {
+    return compiler.style(str, 'my-tag', 'scoped-css')
+  }
+
+  it('should add my-tag to the simple selector', function() {
+    expect(render('h1 { font-size: 150% }'))
+        .to.equal('my-tag h1 { font-size: 150% }')
+  })
+  it('should add my-tag to the multi selector in a line', function() {
+    expect(render('h1 { font-size: 150% } #id { color: #f00 }'))
+        .to.equal('my-tag h1 { font-size: 150% } my-tag #id { color: #f00 }')
+  })
+  it('should add my-tag to the complex selector', function() {
+    expect(render('header a.button:hover { text-decoration: none }'))
+        .to.equal('my-tag header a.button:hover { text-decoration: none }')
+  })
+  it('should add my-tag to the comma-separated selector', function() {
+    expect(render('h2, h3 { border-bottom: 1px solid #000 }'))
+        .to.equal('my-tag h2,my-tag h3 { border-bottom: 1px solid #000 }')
+  })
+  it('should add my-tag to the attribute selector', function() {
+    expect(render('i[class=twitter] { background: #55ACEE }'))
+        .to.equal('my-tag i[class=twitter] { background: #55ACEE }')
+  })
+  it('should add my-tag to the selector with a backslash', function() {
+    expect(render('a:after { content: "\25BA" }'))
+        .to.equal('my-tag a:after { content: "\25BA" }')
+  })
+  it('should add my-tag to the selector with multi-line definitions', function() {
+    expect(render('header {\n  text-align: center;\n  background: rgba(0,0,0,.2);\n}'))
+        .to.equal('my-tag header { text-align: center; background: rgba(0,0,0,.2); }')
+  })
+  it('should add my-tag to the root selector', function() {
+    expect(render(':scope { display: block }'))
+        .to.equal('my-tag { display: block }')
+  })
+  it('should add my-tag to the nested root selector', function() {
+    expect(render(':scope > ul { padding: 0 }'))
+        .to.equal('my-tag > ul { padding: 0 }')
+  })
+  it('should not add my-tag to @font-face', function() {
+    expect(render('@font-face { font-family: "FontAwesome" }'))
+        .to.equal('@font-face { font-family: "FontAwesome" }')
+  })
+  it('should not add my-tag to @media, and should add it to the selector inside', function() {
+    expect(render('@media (min-width: 500px) {\n  header {\n    text-align: left;\n  }\n}'))
+        .to.equal('@media (min-width: 500px) { my-tag header { text-align: left; } }')
+  })
+
+})


### PR DESCRIPTION
This PR add the functionality of 'Scoped CSS emulation' to Riot.js. See #381

```html
<my-tag>
  <style scoped>
    :scope { display: block; border: 2px }
    h3 { color: blue }
  </style>
</my-tag>
```

The style part will translate into CSS below.

```css
my-tag { display: block; border: 2px }
my-tag h3 { color: blue }
```