### PR TITLE
Transform dashed options to snake case

### DIFF
--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -23,6 +23,7 @@ function Tag(impl, conf) {
       })
     }
     attr[name] = el.value
+    attr[el.name] = el.value
   })
 
   // options

--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -18,7 +18,7 @@ function Tag(impl, conf) {
   each(root.attributes, function(el) {
     var name = el.name
     if (~name.indexOf('-')) {
-      name = name.replace(/-([a-z])/i, function (i) {
+      name = name.replace(/-([a-z])/gi, function (i) {
         return i[1].toUpperCase()
       })
     }

--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -16,7 +16,13 @@ function Tag(impl, conf) {
 
   // grab attributes
   each(root.attributes, function(el) {
-    attr[el.name] = el.value
+    var name = el.name
+    if (~name.indexOf('-')) {
+      name = name.replace(/-([a-z])/i, function (i) {
+        return i[1].toUpperCase()
+      })
+    }
+    attr[name] = el.value
   })
 
   // options


### PR DESCRIPTION
```
<tag my-opt="abc" />
```

By default opts is `{ "my-opt": "abc" }` and access to option is not friendly: `opts['my-opt']`.