### PR TITLE
make tmpl work with node global when window is undefined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ WATCH = "\
 test:
 	@ make eslint
 	# test the node compiler
-	@ ./node_modules/mocha/bin/_mocha test/runner.js -R spec
+	@ RIOT=../dist/riot/riot.js ./node_modules/mocha/bin/_mocha test/runner.js -R spec
 	# test riot
 	@ ./node_modules/karma/bin/karma start test/karma.conf.js
 

--- a/lib/tmpl.js
+++ b/lib/tmpl.js
@@ -165,7 +165,7 @@ var tmpl = (function() {
     return !s ? '' : '(function(v){try{v='
 
         // prefix vars (name => data.name)
-        + (s.replace(re_vars, function(s, _, v) { return v ? '(d.'+v+'===undefined?window.'+v+':d.'+v+')' : s })
+        + (s.replace(re_vars, function(s, _, v) { return v ? '(d.'+v+'===undefined?(typeof window!==\'undefined\'?window.'+v+':global.'+v+'):d.'+v+')' : s })
 
           // break the expression if its empty (resulting in undefined value)
           || 'x')

--- a/test/runner.js
+++ b/test/runner.js
@@ -2,7 +2,6 @@ var isNode = typeof window === 'undefined'
 
 describe('Riot Tests', function() {
   if (isNode) {
-    global.window = global
     global.riot = require('../lib/node')
     global.compiler = require('../lib/compiler')
     global.expect = require('expect.js')

--- a/test/specs/tmpl.js
+++ b/test/specs/tmpl.js
@@ -22,7 +22,7 @@ describe('Tmpl', function() {
   it('compiles specs', function() {
 
     expect(render('{ a: !no, b: yes }')).to.equal('a b')
-    expect(render("{ 'a b': yes }")).to.equal('a b')
+    expect(render('{ "a b": yes }')).to.equal('a b')
     expect(render('{ "a_b-c3": yes }')).to.equal('a_b-c3')
     expect(render('{ y: false || null || !no && yes }')).to.equal('y')
     expect(render('{ y: 4 > 2 }')).to.equal('y')
@@ -100,8 +100,8 @@ describe('Tmpl', function() {
     expect(render('{ nonExistingVar ? "yes" : "no" }')).to.equal('no')
     expect(render('{ !nonExistingVar ? "yes" : "no" }')).to.equal('yes')
 
-    window.globalVar = 5
-    expect(render('{ globalVar }')).to.equal(window.globalVar)
+    globalVar = 5
+    expect(render('{ globalVar }')).to.equal(globalVar)
 
     expect(render('{ !text }')).to.equal(true)
 


### PR DESCRIPTION
tmpl function should use `global` in case of `node/io.js` where `window` is `undefined`