### PR TITLE
Allow first dash in object key

### DIFF
--- a/lib/tmpl.js
+++ b/lib/tmpl.js
@@ -146,7 +146,7 @@ var tmpl = (function() {
 
       // if object literal, return trueish keys
       // e.g.: { show: isOpen(), done: item.done } -> "show done"
-      ? '[' + s.replace(/\W*([\w- ]+)\W*:([^,]+)/g, function(_, k, v) {
+      ? '[' + s.replace(/[^A-Za-z0-9_-]*([\w- ]+)\W*:([^,]+)/g, function(_, k, v) {
 
         return v.replace(/[^&|=!><]+/g, wrap) + '?"' + k.trim() + '":"",'
 


### PR DESCRIPTION
First dash is removed from object key.

```html
<div class="item { '-active': true }" href="#"></div>
```
rendered to:

```html
<div class="item active" href="#"></div>
```

See [fiddle](http://jsfiddle.net/zenwalker/4v7nfhn6/1/).