### PR TITLE
Use location.href to extract hash

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -10,7 +10,7 @@
       current
 
   function hash() {
-    return loc.hash.slice(1)
+    return loc.href.split('#')[1] || ''
   }
 
   function parser(path) {

--- a/test/specs/route.js
+++ b/test/specs/route.js
@@ -14,7 +14,7 @@ describe('Route', function() {
     riot.route(function(first, second, params) {
       counter++
       expect(['mummypowder', '!']).to.contain(first)
-      expect(['logo-and-key', 'user']).to.contain(second)
+      expect(['logo-and-key', 'user', 'http%3A%2F%2Fxxx.yyy']).to.contain(second)
       expect([undefined, 'activation?token=xyz']).to.contain(params)
     })
 
@@ -46,7 +46,9 @@ describe('Route', function() {
 
     riot.route('!/user/activation?token=xyz')
 
-    expect(counter).to.be(3)
+    riot.route('mummypowder/http%3A%2F%2Fxxx.yyy')
+
+    expect(counter).to.be(4)
 
   })
 })


### PR DESCRIPTION
There is a bug in firefox which means that location.hash contains the decoded URL. e.g

if the url is 

    xxx.com/#link/http%3A%2Fwhy.com

Then:

location.hash will be: 
    #link/http://why.com

and

location.href will be: 
    xxx.com/#link/http%3A%2Fwhy.com

So location.href contains the correct value but location.hash does not since it contains the decoded value. The fix is to use location.href to extract the hash.

More details on this page:
http://stackoverflow.com/questions/1703552/encoding-of-window-location-hash