### PR TITLE
Fixes browserify/babel interoperability

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,5 +1,5 @@
 
-;(function(is_server) {
+;(function(window) {
 
   var BOOL_ATTR = ('allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare,default,'+
     'defaultchecked,defaultmuted,defaultselected,defer,disabled,draggable,enabled,formnovalidate,hidden,'+
@@ -257,7 +257,7 @@
 
 
   // io.js (node)
-  if (is_server) {
+  if (!window) {
     this.riot = require(process.env.RIOT || '../riot')
     return module.exports = {
       compile: compile,
@@ -268,7 +268,7 @@
   }
 
   // browsers
-  var doc = document,
+  var doc = window.document,
       promise,
       ready
 
@@ -371,4 +371,4 @@
   // @deprecated
   riot.mountTo = riot.mount
 
-})(!this.top)
+})(typeof window != 'undefined' ? window : undefined)

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,10 +1,10 @@
 
-;(function(riot, evt) {
+;(function(riot, evt, window) {
 
   // browsers only
-  if (!this.top) return
+  if (!window) return
 
-  var loc = location,
+  var loc = window.location,
       fns = riot.observable(),
       win = window,
       current
@@ -48,4 +48,4 @@
 
   win.addEventListener ? win.addEventListener(evt, emit, false) : win.attachEvent('on' + evt, emit)
 
-})(riot, 'hashchange')
+})(riot, 'hashchange', window)

--- a/lib/wrap/prefix.js
+++ b/lib/wrap/prefix.js
@@ -1,7 +1,6 @@
 /* Riot WIP, @license MIT, (c) 2015 Muut Inc. + contributors */
 
-;(function() {
+;(function(window) {
+  'use strict'
 
   var riot = { version: 'WIP', settings: {} }
-
-  'use strict'

--- a/lib/wrap/suffix.js
+++ b/lib/wrap/suffix.js
@@ -1,16 +1,12 @@
-  
+
   // share methods for other riot parts, e.g. compiler
   riot.util = { brackets: brackets, tmpl: tmpl }
 
-  // support CommonJS
+  // support CommonJS, AMD & browser
   if (typeof exports === 'object')
     module.exports = riot
-
-  // support AMD
   else if (typeof define === 'function' && define.amd)
     define(function() { return riot })
-
-  // support browser
   else
     window.riot = riot
 

--- a/lib/wrap/suffix.js
+++ b/lib/wrap/suffix.js
@@ -12,6 +12,6 @@
 
   // support browser
   else
-    this.riot = riot
+    window.riot = riot
 
-})();
+})(typeof window != 'undefined' ? window : undefined);


### PR DESCRIPTION
Previously the `lib/wrap/prefix.js` was defined as the following.

```js
;(function() {

  var riot = { version: 'WIP', settings: {} }

  'use strict'
```
However since the  `'use strict'` was not the top most statement in the function it was just ignored. This means `this` was equal to the `window` object.

Since Browserfiy adds some valid  `'use strict'` statement in its generated build, `this` became an undefined value which explained #459 

The second commit is more a workaround to make the codebase to work with Browserfiy + Babel. I wasn't able to identify the root cause since Browserfiy & Babel seemed to behave has expected but for some reason the error in the issue #324 is generated at some point due to some weird output generated when ASI is used (see https://github.com/babel/babel/issues/946)

Since the weird generated ouput was some prefectly valid JS I wasn't able to create a PR in Babel and I wasn't able to understand where the error was generated. So as a workaround the second commit just reorder some comments to make the transpilation to work out of the box.
