### PR TITLE
#472 package.json: { "main": "lib/node.js" } => { "main": "riot.js" }

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "bin": {
     "riot": "lib/cli.js"
   },
-  "main": "lib/node.js",
+  "main": "riot.js",
   "browser": "riot.js",
   "spm": {
     "main": "riot.js",


### PR DESCRIPTION
I made the change for my flux riot example https://github.com/mingliangfeng/flux-riot, but feel it might be right as common usage.

see discussion for issue https://github.com/muut/riotjs/issues/472.