### PR TITLE
fix _each to handle removed item from array #509 & comment typo fix

### DIFF
--- a/lib/tag/each.js
+++ b/lib/tag/each.js
@@ -94,6 +94,8 @@ function _each(dom, parent, expr) {
         tag.unmount()
         rendered.splice(pos, 1)
         tags.splice(pos, 1)
+        // to let "each" know that this item is removed
+        return false
       }
 
     })

--- a/lib/tag/util.js
+++ b/lib/tag/util.js
@@ -2,7 +2,7 @@
 function each(els, fn) {
   for (var i = 0, len = (els || []).length, el; i < len; i++) {
     el = els[i]
-    // return false -> reomve current item during loop
+    // return false -> remove current item during loop
     if (el != null && fn(el, i) === false) i--
   }
   return els


### PR DESCRIPTION
according to function each in util:
```javascript
function each(els, fn) {
  for (var i = 0, len = (els || []).length, el; i < len; i++) {
    el = els[i]
    // return false -> remove current item during loop
    if (el != null && fn(el, i) === false) i--
  }
  return els
}
```
fn should return false if it removes item from els during running

however it was not doing that:
```javascript
      if (tag) {
        tag.unmount()
        rendered.splice(pos, 1)
        tags.splice(pos, 1)
      }
```

therefore I made it return false:
```javascript
      if (tag) {
        tag.unmount()
        rendered.splice(pos, 1)
        tags.splice(pos, 1)
        // to let "each" know that this item is removed
        return false
      }
```