### PR TITLE
Add ES6 online transpiler support

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -111,6 +111,9 @@
   }
 
   function es6(js) {
+    if (typeof exports === 'undefined') {
+      return babel.transform(js, { blacklist: ['useStrict'] }).code
+    }
     return require('babel').transform(js, { blacklist: ['useStrict'] }).code
   }
 


### PR DESCRIPTION
If you use (from Babel) :

    <!-- Load Babel scripts -->
    <script src="node_modules/babel/browser-polyfill.js"></script>
    <script src="node_modules/babel/browser.js"></script>

You can write riot tags like that:

    <yo-bob>
        <h1>{label}</h1>
        <h1>{subLabel}</h1>
        <script type="es6">
            let firstName = "Bob";
            let lastName = "Morane";
            this.label = 'Yo Bob';
            this.subLabel = `Hello ${firstName} ${lastName}`;
        </script>
    </yo-bob>