### PR TITLE
Add Coffeescript online transpiler support

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -107,6 +107,9 @@
   }
 
   function coffee(js) {
+    if (typeof exports === 'undefined') {
+      return CoffeeScript.compile(js, { bare: true })
+    }
     return require('coffee-script').compile(js, { bare: true })
   }
 


### PR DESCRIPTION
If you include `coffee-script.js` to your html page (` <script src="js/coffee-script.js"></script>`), then you can write riot tags like that:

    <hi-bob>
        <h1>{label}</h1>
        <script type="text/coffeescript">
            @label = 'Hi Bob Morane'
        </script>
    </hi-bob>