### PR TITLE
fix failing reverse specs

### DIFF
--- a/lib/tag/each.js
+++ b/lib/tag/each.js
@@ -101,9 +101,7 @@ function _each(dom, parent, expr) {
     })
 
     // mount new / reorder
-    var nodes = root.childNodes,
-        prev_index = [].indexOf.call(nodes, prev)
-
+    var prev_base = [].indexOf.call(root.childNodes, prev) + 1
     each(items, function(item, i) {
 
       // start index search from position based on the current i
@@ -126,11 +124,12 @@ function _each(dom, parent, expr) {
       }
 
       // mount new
+      var nodes = root.childNodes
       if (oldPos < 0) {
         if (!checksum && expr.key) var _item = mkitem(expr, item, pos)
 
         var tag = new Tag({ tmpl: template }, {
-          before: nodes[prev_index + 2 + pos],
+          before: nodes[prev_base + pos],
           parent: parent,
           root: root,
           item: _item
@@ -152,7 +151,7 @@ function _each(dom, parent, expr) {
 
       // reorder
       if (pos != oldPos) {
-        root.insertBefore(nodes[prev_index + oldPos + 1], nodes[prev_index + pos + 1])
+        root.insertBefore(nodes[prev_base + oldPos], nodes[prev_base + (pos > oldPos ? pos + 1 : pos)])
         return add(pos, rendered.splice(oldPos, 1)[0], tags.splice(oldPos, 1)[0])
       }
 

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -250,10 +250,18 @@ describe('Compiler Browser', function() {
     button.onclick({})
     expect(root.getElementsByTagName('li').length).to.be(10)
     expect(root.getElementsByTagName('ul')[0].innerHTML.trim()).to.be('<li> 0 item #0 </li><li> 1 item #1 </li><li> 2 item #2 </li><li> 3 item #3 </li><li> 4 item #4 </li><li> 5 item #5 </li><li> 6 item #6 </li><li> 7 item #7 </li><li> 8 item #8 </li><li> 9 item #9 </li>'.trim())
-    // tag.items.reverse()
-    // tag.update()
-    // expect(root.getElementsByTagName('li').length).to.be(10)
-    // expect(root.getElementsByTagName('ul')[0].innerHTML.trim()).to.be('<li> 0 item #9 </li><li> 1 item #8 </li><li> 2 item #7 </li><li> 3 item #6 </li><li> 4 item #5 </li><li> 5 item #4 </li><li> 6 item #3 </li><li> 7 item #2 </li><li> 8 item #1 </li><li> 9 item #0 </li>'.trim())
+
+    tag.items.reverse()
+    tag.update()
+    expect(root.getElementsByTagName('li').length).to.be(10)
+    expect(root.getElementsByTagName('ul')[0].innerHTML.trim()).to.be('<li> 0 item #9 </li><li> 1 item #8 </li><li> 2 item #7 </li><li> 3 item #6 </li><li> 4 item #5 </li><li> 5 item #4 </li><li> 6 item #3 </li><li> 7 item #2 </li><li> 8 item #1 </li><li> 9 item #0 </li>'.trim())
+
+    var temp_item = tag.items[1]
+    tag.items[1] = tag.items[8]
+    tag.items[8] = temp_item
+    tag.update()
+    expect(root.getElementsByTagName('ul')[0].innerHTML.trim()).to.be('<li> 0 item #9 </li><li> 1 item #1 </li><li> 2 item #7 </li><li> 3 item #6 </li><li> 4 item #5 </li><li> 5 item #4 </li><li> 6 item #3 </li><li> 7 item #2 </li><li> 8 item #8 </li><li> 9 item #0 </li>'.trim())
+
     tag.items = []
     tag.update()
     expect(root.getElementsByTagName('li').length).to.be(0)


### PR DESCRIPTION
Two main changes:

1. "var nodes = root.childNodes" is moved to within the loop, as root.childNodes will increase/change due to effect in  each loop step;
2. the DOM node insertion position is different when the element is moved to left and right, change
```
root.insertBefore(nodes[prev_index + oldPos + 1], nodes[prev_index + pos + 1])
```
to
```
root.insertBefore(nodes[prev_base + oldPos], nodes[prev_base + (pos > oldPos ? pos + 1 : pos)])
```

