### PR TITLE
Added support for CSS preprocessors

### DIFF
--- a/doc/compiler.md
+++ b/doc/compiler.md
@@ -171,9 +171,11 @@ The compile function takes a string and returns a string.
 
 ## Pre-processors
 
-This is the main fruit of pre- compilation. You can use your favourite pre- processor to create custom tags. Both HTML and JavaScript processor can be customized.
+This is the main fruit of pre- compilation. You can use your favourite pre- processor to create custom tags. HTML, CSS and JavaScript processor can be customized.
 
-The source language is specified with `--type` or `-t` argument on the command line or you can define the language on the script tag as follows:
+The source language is specified with `--type` or `-t` argument on the command line or you can define the language on the script tag.
+
+The same applies to CSS preprocessors. They can be specified on the command line with `--styletype` or `-s` or directly on the style element. For example:
 
 ```
 <my-tag>
@@ -182,6 +184,20 @@ The source language is specified with `--type` or `-t` argument on the command l
   <script type="coffeescript">
     @hello = 'world'
   </script>
+
+  <style type="less">
+    @nice-blue: #5B83AD;
+    @light-blue: @nice-blue + #111;
+
+    my-tag {
+      color: @light-blue;
+
+      h3 {
+        color: @nice-blue;
+      }
+    }
+  </style>
+
 </my-tag>
 ```
 
@@ -332,7 +348,14 @@ As you notice, you can define the script type on the template as well. Above we 
 npm install jade
 ```
 
+### SASS, LESS and Stylus
 
+Style blocks can be processed with the `styletype` configuration option. For example:
+
+``` sh
+# use Stylus CSS pre-processor
+riot --styletype stylus source.tag
+```
 
 ### Any language
 

--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -148,6 +148,21 @@ You can put a `style` tag inside. Riot.js automatically takes it out and injects
 </todo>
 ```
 
+### CSS pre-processor
+
+You can specify a CSS pre-processor with `type` attribute. For example:
+
+```
+<style type="less">
+  # your style is here
+</style>
+````
+
+Currently available options are "less", "sass", "stylus" and "none". You can also prefix the language with "text/", such as "text/stylus".
+
+See [css pre processors](/riotjs/compiler.html#pre-processors) for more details.
+
+
 ### Scoped CSS
 
 [Scoped CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope) is also available. The example below is equivalent to the first one.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -30,6 +30,7 @@ var methods = {
       '  -w, --watch     Watch for changes',
       '  -c, --compact   Minify </p> <p> to </p><p>',
       '  -t, --type      JavaScript pre-processor. Built-in support for: es6, coffeescript, typescript, livescript, none',
+      '  -s, --styletype CSS pre-processor. Built-in support for: less, sass, stylus, none',
       '  --template      HTML pre-processor. Built-in suupport for: jade',
       '  --whitespace    Preserve newlines and whitepace',
       '  --brackets      Change brackets used for expressions. Defaults to { }',
@@ -56,6 +57,7 @@ var methods = {
       '  riot --compact foo bar',
       '  riot foo bar --compact',
       '  riot test.tag --type coffeescript --expr',
+      '  riot stylish.tag --styletype sass',
       ''
     ].join('\n'))
   },
@@ -155,7 +157,7 @@ function cli() {
 
   var args = require('minimist')(process.argv.slice(2), {
     boolean: ['watch', 'compact', 'help', 'version', 'whitespace'],
-    alias: { w: 'watch', c: 'compact', h: 'help', v: 'version', t: 'type' }
+    alias: { w: 'watch', c: 'compact', h: 'help', v: 'version', t: 'type', s: 'styletype' }
   })
 
   // Translate args into options hash
@@ -165,6 +167,7 @@ function cli() {
       compact: args.compact,
       template: args.template,
       type: args.type,
+      styletype: args.styletype,
       brackets: args.brackets,
       expr: args.expr
     },

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -33,6 +33,13 @@
     ls: livescript
   }
 
+  var CSS_PARSERS = {
+    none: plaincss,
+    stylus: stylus,
+    sass: sass,
+    less: less
+  }
+
   var LINE_TAG = /^<([\w\-]+)>(.*)<\/\1>/gim,
       QUOTE = /=({[^}]+})([\s\/\>])/g,
       SET_ATTR = /([\w\-]+)=(["'])([^\2]+?)\2/g,
@@ -40,7 +47,7 @@
       // (tagname) (html) (javascript) endtag
       CUSTOM_TAG = /^<([\w\-]+)>([^\x00]*[\w\/}"']>$)?([^\x00]*?)^<\/\1>/gim,
       SCRIPT = /<script(\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/script>/gm,
-      STYLE = /<style(\s+type=['"]?([^>'"]+)['"]?|\s+scoped)?>([^\x00]*?)<\/style>/gm,
+      STYLE = /<style(?:\s+type=['"]?([^>'"]+)['"]?)?(\s+scoped)?>([^\x00]*?)<\/style>/gm,
       CSS_SELECTOR = /(^|\}|\{)\s*([^\{\}]+)\s*(?=\{)/g,
       CSS_COMMENT = /\/\*[^\x00]*?\*\//gm,
       HTML_COMMENT = /<!--.*?-->/g,
@@ -173,7 +180,29 @@
 
   }
 
-  function scopedCSS (tag, style) {
+  function plaincss(css) {
+    return css
+  }
+
+  function stylus(css) {
+    return require('stylus').render(css)
+  }
+
+  function less(css) {
+    require('less').render(css, function(err, output) {
+      if (err) throw new Error('Error processing LESS: ' +
+                  err.line + ':' + err.index + ' "' + err.message + '"')
+      css = output.css
+    })
+
+    return css
+  }
+
+  function sass(css) {
+    return require('node-sass').renderSync({ data: css }).css
+  }
+
+  function scopedCSS(tag, style) {
     return style.replace(CSS_COMMENT, '').replace(CSS_SELECTOR, function (m, p1, p2) {
       return p1 + ' ' + p2.split(/\s*,\s*/g).map(function(sel) {
         return sel[0] == '@' ? sel : tag + ' ' + sel.replace(/:scope\s*/, '')
@@ -193,8 +222,10 @@
     return parser(html)
   }
 
-  function compileCSS(style, tag, type) {
-    if (type == 'scoped-css') style = scopedCSS(tag, style)
+  function compileCSS(style, opts, tag, type, scoped) {
+    var parser = CSS_PARSERS[type] || plaincss
+    style = parser(style)
+    if (scoped) style = scopedCSS(tag, style)
     return style.replace(/\s+/g, ' ').replace(/\\/g, '\\\\').replace(/'/g, "\\'").trim()
   }
 
@@ -226,7 +257,7 @@
       var type = opts.type
 
       if (!js.trim()) {
-        html = html.replace(SCRIPT, function(_, fullType, _type, script) {
+        html = html.replace(SCRIPT, function(_, _type, script) {
           if (_type) type = _type.replace('text/', '')
           js = script
           return ''
@@ -234,12 +265,14 @@
       }
 
       // styles in <style> tag
-      var styleType = 'css',
-          style = ''
+      var styleType = opts.styletype,
+          style = '',
+          styleScoped = false
 
-      html = html.replace(STYLE, function(_, fullType, _type, _style) {
-        if (fullType && 'scoped' == fullType.trim()) styleType = 'scoped-css'
-          else if (_type) styleType = _type.replace('text/', '')
+
+      html = html.replace(STYLE, function(_, _type, _scoped, _style) {
+        styleScoped = !!_scoped
+        if (_type) styleType = _type.replace('text/', '')
         style = _style
         return ''
       })
@@ -247,7 +280,7 @@
       return mktag(
         tagName,
         compileHTML(html, opts, type),
-        compileCSS(style, tagName, styleType),
+        compileCSS(style, opts, tagName, styleType, styleScoped),
         compileJS(js, opts, type)
       )
 

--- a/test/specs/compiler/scoped-css.js
+++ b/test/specs/compiler/scoped-css.js
@@ -1,7 +1,7 @@
 describe('Scoped CSS', function() {
 
   function render(str) {
-    return compiler.style(str, 'my-tag', 'scoped-css')
+    return compiler.style(str, {}, 'my-tag', 'css', true)
   }
 
   it('add my-tag to the simple selector', function() {


### PR DESCRIPTION
Adds support for stylus, sass and less via -s on the command line or type="stylus" on a style element. As far as I can tell this implements what was started in #373

There're no new tests, I'm not sure what the preferred way would be. If it's OK to require all the preprocessors to be installed, I could probably do something similar to the stuff that's already in the compiler suite? I'd be happy to amend the pull request as appropriate.

This changes the signature of compileCSS, which is exported, but not sure if it's intended for any kind of public usage.
