### PR TITLE
CLI compiler support for AMD and CommonJS

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -92,8 +92,6 @@ var methods = {
 
     function parse(from) { return compiler.compile(sh.cat(from).replace(/^\uFEFF/g, /* strips BOM */''), opt.compiler) }
     function toFile(from, to) {
-      console.log(opt)
-
       from.map(function (path, i) {
         var out = '';
 
@@ -120,7 +118,7 @@ var methods = {
     ;(opt.flow[1] == 'f' ? toFile : toDir)(from, to)
 
     // Print what's been done
-    
+
     from.map(function(src, i) {
       log(toRelative(src) + ' -> ' + toRelative(to[i] || to[0]))
     })

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -93,25 +93,25 @@ var methods = {
     function parse(from) { return compiler.compile(sh.cat(from).replace(/^\uFEFF/g, /* strips BOM */''), opt.compiler) }
     function toFile(from, to) {
       from.map(function (path, i) {
-        var out = '';
+        var out = ''
 
         if (opt.compiler.modular && i === 0) {
-          out = "(function(tagger) {\n\
-  if (typeof define === 'function' && define.amd) {\n\
-    define(['riot'], function(riot) { tagger(riot); });\n\
-  } else if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {\n\
-    tagger(require('riot'));\n\
-  } else {\n\
-    tagger(window.riot);\n\
-  }\n\
-})(function(riot) {\n";
+          out += '(function(tagger) {\n'
+          out += '  if (typeof define === \'function\' && define.amd) {\n'
+          out += '    define([\'riot\'], function(riot) { tagger(riot); });\n'
+          out += '  } else if (typeof module !== \'undefined\' && typeof module.exports !== \'undefined\') {\n'
+          out += '    tagger(require(\'riot\'));\n'
+          out += '  } else {\n'
+          out += '    tagger(window.riot);\n'
+          out += '  }\n'
+          out += '})(function(riot) {\n'
         }
 
-        out += parse(path);
+        out += parse(path)
 
-        if (opt.compiler.modular && i === from.length - 1) out += '\n});';
+        if (opt.compiler.modular && i === from.length - 1) out += '\n});'
 
-        return out;
+        return out
       }).join('\n').to(to[0])
     }
     function toDir(from, to) { from.map(function(from, i) { parse(from).to(to[i]) }) }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,9 +12,9 @@
 //
 
 var ph = require('path'),
-    sh = require('shelljs'),
-    chokidar = require('chokidar'),
-    compiler = require('./compiler')
+  sh = require('shelljs'),
+  chokidar = require('chokidar'),
+  compiler = require('./compiler')
 
 var methods = {
 
@@ -30,6 +30,7 @@ var methods = {
       '  -w, --watch     Watch for changes',
       '  -c, --compact   Minify </p> <p> to </p><p>',
       '  -t, --type      JavaScript pre-processor. Built-in support for: es6, coffeescript, typescript, livescript, none',
+      '  -m, --modular   AMD and CommonJS',
       '  --template      HTML pre-processor. Built-in suupport for: jade',
       '  --whitespace    Preserve newlines and whitepace',
       '  --brackets      Change brackets used for expressions. Defaults to { }',
@@ -78,8 +79,8 @@ var methods = {
     }) }
 
     var from = opt.flow[0] == 'f' ? [opt.from] : find(opt.from),
-        base = opt.flow[0] == 'f' ? ph.dirname(opt.from) : opt.from,
-          to = opt.flow[1] == 'f' ? [opt.to] : remap(from, opt.to, base)
+      base = opt.flow[0] == 'f' ? ph.dirname(opt.from) : opt.from,
+      to = opt.flow[1] == 'f' ? [opt.to] : remap(from, opt.to, base)
 
     // Create any necessary dirs
 
@@ -90,12 +91,36 @@ var methods = {
     // Process files
 
     function parse(from) { return compiler.compile(sh.cat(from).replace(/^\uFEFF/g, /* strips BOM */''), opt.compiler) }
-    function toFile(from, to) { from.map(parse).join('\n').to(to[0]) }
+    function toFile(from, to) {
+      console.log(opt)
+
+      from.map(function (path, i) {
+        var out = '';
+
+        if (opt.compiler.modular && i === 0) {
+          out = "(function(tagger) {\n\
+  if (typeof define === 'function' && define.amd) {\n\
+    define(['riot'], function(riot) { tagger(riot); });\n\
+  } else if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {\n\
+    tagger(require('riot'));\n\
+  } else {\n\
+    tagger(window.riot);\n\
+  }\n\
+})(function(riot) {\n";
+        }
+
+        out += parse(path);
+
+        if (opt.compiler.modular && i === from.length - 1) out += '\n});';
+
+        return out;
+      }).join('\n').to(to[0])
+    }
     function toDir(from, to) { from.map(function(from, i) { parse(from).to(to[i]) }) }
     ;(opt.flow[1] == 'f' ? toFile : toDir)(from, to)
 
     // Print what's been done
-
+    
     from.map(function(src, i) {
       log(toRelative(src) + ' -> ' + toRelative(to[i] || to[0]))
     })
@@ -146,7 +171,6 @@ function init(opt) {
   // Determine the input/output types
 
   opt.flow = (ext.test(opt.from) ? 'f' : 'd') + (/\.js$/.test(opt.to) ? 'f' : 'd')
-
 }
 
 function cli() {
@@ -154,8 +178,8 @@ function cli() {
   // Get CLI arguments
 
   var args = require('minimist')(process.argv.slice(2), {
-    boolean: ['watch', 'compact', 'help', 'version', 'whitespace'],
-    alias: { w: 'watch', c: 'compact', h: 'help', v: 'version', t: 'type' }
+    boolean: ['watch', 'compact', 'help', 'version', 'whitespace', 'modular'],
+    alias: { w: 'watch', c: 'compact', h: 'help', v: 'version', t: 'type', m: 'modular' }
   })
 
   // Translate args into options hash
@@ -166,7 +190,8 @@ function cli() {
       template: args.template,
       type: args.type,
       brackets: args.brackets,
-      expr: args.expr
+      expr: args.expr,
+      modular: args.modular
     },
     ext: args.ext,
     from: args._.shift(),


### PR DESCRIPTION
The RiotJS library supports AMD and CommonJS, yet the server side compiler does not when converting .tag files into .js files.

The result of this is that when using RequireJS or Browserify the browser tries to execute `riot.tag()` and the `riot` object is undefined since it has not been bound to the `window` object.

This commit provides a CLI `--modular -m` argument to optionally incorporate these standards into the generated JS tags.