### PR TITLE
Making sure Tag.update() is called in the most effective way

### DIFF
--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -57,9 +57,7 @@ function Tag(impl, conf, innerHTML) {
     // parse layout after init. fn may calculate args for nested custom tags
     parseExpressions(dom, self, expressions)
 
-    if (!self.parent) {
-      self.update()
-    }
+    if (!self.parent) self.update()
 
     // internal use only, fixes #403
     self.trigger('premount')

--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -57,7 +57,9 @@ function Tag(impl, conf, innerHTML) {
     // parse layout after init. fn may calculate args for nested custom tags
     parseExpressions(dom, self, expressions)
 
-    self.update()
+    if (!self.parent) {
+      self.update()
+    }
 
     // internal use only, fixes #403
     self.trigger('premount')


### PR DESCRIPTION
On page load, this makes sure that update is called only once per tag and in the most effective order.