### PR TITLE
Fix typos in guide

### DIFF
--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -724,7 +724,7 @@ will mount the `ul` element shown above as if it were `<my-tag></my-tag>`
 
 ## Server-side rendering | #server-side
 
-Riot supports server-side rendering, with Node/io.js you can simple require tags and render to html:
+Riot supports server-side rendering, with Node/io.js you can simply require tags and render to html:
 
 ```
 var riot = require('riot')
@@ -840,4 +840,4 @@ And here we mount the application
 
 On the above setup the other tags on the system do not need to know about each other since they can simply listen to the "login" event and do what they please.
 
-Observable is a classic building block for a decoupled (modular) appliction.
+Observable is a classic building block for a decoupled (modular) application.


### PR DESCRIPTION
Now it's pointing to the `dev` branch so we can close the other PR (https://github.com/muut/riotjs/pull/623).