### PR TITLE
Added possibility to change compiled file extension

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -36,7 +36,7 @@ var methods = {
       '  --brackets      Change brackets used for expressions. Defaults to { }',
       '  --expr          Run expressions trough parser defined with --type',
       '  --ext           Change tag file extension. Defaults to .tag',
-      '  --compiled_ext  Change compiled tag file extension. Defaults to .js',
+      '  --compiledExt   Change compiled tag file extension. Defaults to .js',
       '',
       'Build a single .tag file:',
       '',
@@ -76,7 +76,7 @@ var methods = {
     var tmp = /\/[^.~][^~/]+$/ // skip temporary files (created by editors), e.g. /.name.tag, /~name.tag, /name~.tag
     function find(from) { return sh.find(from).filter(function(f) { return ext.test(f) && tmp.test(f) }) }
     function remap(from, to, base) { return from.map(function(from) {
-      return ph.join(to, ph.relative(base, from).replace(ext, '.'+compiled_ext))
+      return ph.join(to, ph.relative(base, from).replace(ext, '.'+compiledExt))
     }) }
 
     var from = opt.flow[0] == 'f' ? [opt.from] : find(opt.from),
@@ -143,7 +143,7 @@ var methods = {
 
 
 var ext
-var compiled_ext
+var compiledExt
 
 function init(opt) {
 
@@ -152,8 +152,8 @@ function init(opt) {
   if (init.called) return
   init.called = true
 
-  if (!opt.compiled_ext) opt.compiled_ext = 'js'
-  compiled_ext = opt.compiled_ext
+  if (!opt.compiledExt) opt.compiledExt = 'js'
+  compiledExt = opt.compiledExt
 
   if (!opt.ext) opt.ext = 'tag'
   ext = RegExp('\\.' + opt.ext + '$')
@@ -196,7 +196,7 @@ function cli() {
       expr: args.expr,
       modular: args.modular
     },
-    compiled_ext: args.compiled_ext,
+    compiledExt: args.compiledExt,
     ext: args.ext,
     from: args._.shift(),
     to: args._.shift()

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -36,6 +36,7 @@ var methods = {
       '  --brackets      Change brackets used for expressions. Defaults to { }',
       '  --expr          Run expressions trough parser defined with --type',
       '  --ext           Change tag file extension. Defaults to .tag',
+      '  --compiled_ext  Change compiled tag file extension. Defaults to .js',
       '',
       'Build a single .tag file:',
       '',
@@ -75,7 +76,7 @@ var methods = {
     var tmp = /\/[^.~][^~/]+$/ // skip temporary files (created by editors), e.g. /.name.tag, /~name.tag, /name~.tag
     function find(from) { return sh.find(from).filter(function(f) { return ext.test(f) && tmp.test(f) }) }
     function remap(from, to, base) { return from.map(function(from) {
-      return ph.join(to, ph.relative(base, from).replace(ext, '.js'))
+      return ph.join(to, ph.relative(base, from).replace(ext, '.'+compiled_ext))
     }) }
 
     var from = opt.flow[0] == 'f' ? [opt.from] : find(opt.from),
@@ -142,6 +143,7 @@ var methods = {
 
 
 var ext
+var compiled_ext
 
 function init(opt) {
 
@@ -149,6 +151,9 @@ function init(opt) {
 
   if (init.called) return
   init.called = true
+
+  if (!opt.compiled_ext) opt.compiled_ext = 'js'
+  compiled_ext = opt.compiled_ext
 
   if (!opt.ext) opt.ext = 'tag'
   ext = RegExp('\\.' + opt.ext + '$')
@@ -191,6 +196,7 @@ function cli() {
       expr: args.expr,
       modular: args.modular
     },
+    compiled_ext: args.compiled_ext,
     ext: args.ext,
     from: args._.shift(),
     to: args._.shift()


### PR DESCRIPTION
Since I had the need for the compiled tag file extension to be .tag.js instead of just .js I added this. Maybe someone else also has this need. I use it with webpack loaders to automatically require riot for these files.

```
module: {
        loaders: [
            { test: /\.tag\.js$/, loader: "imports?riot=riot" },
        ]
    }
```