### PR TITLE
Fix for issue 653

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -308,22 +308,29 @@
     var scripts = doc.querySelectorAll('script[type="riot/tag"]'),
         scriptsAmount = scripts.length
 
-    ;[].map.call(scripts, function(script) {
-      var url = script.getAttribute('src')
+    function done() {
+      promise.trigger('ready')
+      ready = true
+      fn && fn()
+    }
 
-      function compileTag(source) {
-        globalEval(source)
-        scriptsAmount--
-        if (!scriptsAmount) {
-          promise.trigger('ready')
-          ready = true
-          fn && fn()
+    if(!scriptsAmount) {
+      done()
+    } else {
+      ;[].map.call(scripts, function(script) {
+        var url = script.getAttribute('src')
+
+        function compileTag(source) {
+          globalEval(source)
+          scriptsAmount--
+          if (!scriptsAmount) {
+            done()
+          }
         }
-      }
 
-      return url ? GET(url, compileTag) : compileTag(unindent(script.innerHTML))
-    })
-
+        return url ? GET(url, compileTag) : compileTag(unindent(script.innerHTML))
+      })
+    }
   }
 
 


### PR DESCRIPTION
When riot+complier.js is used and the script does not manually define any script type="riot/tag" blocks, nothing is mounted. See http://jsfiddle.net/8oum5cgt/

