### PR TITLE
ie8 style err

### DIFF
--- a/lib/tag/vdom.js
+++ b/lib/tag/vdom.js
@@ -14,8 +14,15 @@ function getTag(dom) {
 
 function injectStyle(css) {
   var node = document.createElement('style')
-  node.innerHTML = css
-  document.head.appendChild(node)
+  node.setAttribute("type", "text/css");
+-  document.head.appendChild(node)
++  if(node.styleSheet){
++    node.styleSheet.cssText=css;
++    document.body.appendChild(node);
++  }else{
++    node.innerHTML=css;
++    document.head.appendChild(node);
++  }
 }
 
 function mountTo(root, tagName, opts) {

--- a/riot.js
+++ b/riot.js
@@ -1006,8 +1006,14 @@ function getTag(dom) {
 
 function injectStyle(css) {
   var node = document.createElement('style')
-  node.innerHTML = css
-  document.head.appendChild(node)
+  node.setAttribute("type", "text/css");
+  if(node.styleSheet){
+    node.styleSheet.cssText=css;
+    document.body.appendChild(node);
+  }else{
+    node.innerHTML=css;
+    document.head.appendChild(node);
+  }
 }
 
 function mountTo(root, tagName, opts) {


### PR DESCRIPTION
ie8不支持style的innerHTML，以及将其head的appenChild，增加setAttribute("type", "text/css")，ie8使用style的styleSheet.cssText