### PR TITLE
Make inner content accessible

### DIFF
--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -31,6 +31,7 @@ function Tag(impl, conf, innerHTML) {
     attr[el.name] = el.value
   })
 
+  self.innerHTML = innerHTML
 
   if (dom.innerHTML && !/select/.test(tagName))
     // replace all the yield tags with the tag inner html


### PR DESCRIPTION
Example: 
HTML: ```<my-tag>[ {key: "Value"} ]</my-tag>```

Tag: 
```<my-tag>
# Parse data besides tag attribute
this.items = eval(this.innerHTML)```