### PR TITLE
faster riot.mount.selctAllTags

### DIFF
--- a/lib/tag/vdom.js
+++ b/lib/tag/vdom.js
@@ -47,13 +47,13 @@ riot.tag = function(name, html, css, fn) {
 riot.mount = function(selector, tagName, opts) {
 
   var el,
-      selctAllTags = function(sel) {
-        sel = Object.keys(tagImpl).join(', ')
-        sel.split(',').map(function(t) {
-          sel += ', *[riot-tag="'+ t.trim() + '"]'
-        })
-        return sel
+      selctAllTags = function() {
+        var keys = Object.keys(tagImpl)
+        var list = keys.join(', ')
+        keys.forEach(function(t) { list += ', *[riot-tag="'+ t.trim() + '"]' })  // is trim() neccesary?
+        return list
       },
+      allTags,    // cache for all tags
       tags = []
 
   if (typeof tagName == 'object') { opts = tagName; tagName = 0 }
@@ -63,7 +63,7 @@ riot.mount = function(selector, tagName, opts) {
     if (selector == '*') {
       // select all the tags registered
       // and also the tags found with the riot-tag attribute set
-      selector = selctAllTags(selector)
+      selector = allTags = selctAllTags()
     }
     // or just the ones named like the selector
     el = $$(selector)
@@ -75,7 +75,7 @@ riot.mount = function(selector, tagName, opts) {
   // select all the registered and mount them inside their root elements
   if (tagName == '*') {
     // get all custom tags
-    tagName = selctAllTags(selector)
+    tagName = allTags || selctAllTags()
     // if the root el it's just a single tag
     if (el.tagName) {
       el = $$(tagName, el)


### PR DESCRIPTION
riot.mount.selctAllTags is slow, this alternative function is 55% faster.
I think parameter 'sel' is not neccesary.
In rare cases, cache with allTags var avoids unnecessary call.

See [the test](http://jsperf.com/riot-alternative-selctalltags) in jsperf.com