### PR TITLE
compatibility with pre-compiled tags from earlier versions

### DIFF
--- a/doc/api/tags.md
+++ b/doc/api/tags.md
@@ -270,7 +270,7 @@ Creates a new custom tag "manually" without the compiler.
 - `tagName` the tag name
 - `html` is the layout with [expressions](/riotjs/guide/#expressions)
 - `css` is the style for the tag (optional)
-- `attrs` string of attributes for the tag (optional).  If used without the `css` option, include empty css parameter
+- `attrs` string of attributes for the tag (optional).
 - `constructor` is the initialization function being called before the tag expressions are calculated and before the tag is mounted
 
 

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -21,7 +21,7 @@ function Tag(impl, conf, innerHTML) {
   if(impl.attrs) {
     var attrs = impl.attrs.match(TAG_ATTRIBUTES)
 
-    attrs.map(function(a) {
+    each(attrs, function(a) {
       var kv = a.split(/\s?=\s?/)
       root.setAttribute(kv[0], kv[1].replace(/['"]/g, ''))
     })

--- a/lib/browser/tag/vdom.js
+++ b/lib/browser/tag/vdom.js
@@ -54,7 +54,10 @@ function mountTo(root, tagName, opts) {
 }
 
 riot.tag = function(name, html, css, attrs, fn) {
-  if (typeof attrs == 'function') {fn = attrs; attrs=css}
+  if (typeof attrs == 'function') {
+    fn = attrs
+    if(/^[\w\-]+\s?=/.test(css)) {attrs = css; css = ''} else attrs = ''
+  }
   if (typeof css == 'function') fn = css
   else if (css) injectStyle(css)
   tagImpl[name] = { name: name, tmpl: html, attrs: attrs, fn: fn }

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -237,7 +237,12 @@ describe('Compiler Browser', function() {
 
           '<script type=\"riot\/tag\" src=\"tag\/preserve-attr.tag\"><\/script>',
           '<preserve-attr><\/preserve-attr>',
-          '<div riot-tag="preserve-attr2"><\/div>'
+          '<div riot-tag="preserve-attr2"><\/div>',
+
+          // precompiled tag compatibility
+
+          '<precompiled><\/precompiled>'
+
 
 
     ].join('\r'),
@@ -730,6 +735,17 @@ describe('Compiler Browser', function() {
     expect(tag2.root.className).to.be('double-quote')
     tags.push(tag)
     tags.push(tag2)
+  })
+
+  it('precompiled tag compatibility', function() {
+    riot.tag('precompiled', 'HELLO!', 'precompiled, [riot-tag="precompiled"]  { color: red }', function(opts) {
+      this.nothing = opts.nothing
+    })
+
+    var tag = riot.mount('precompiled')[0]
+    expect(window.getComputedStyle(tag.root, null).color).to.be('rgb(255, 0, 0)')
+    tags.push(tag)
+
   })
 
 })


### PR DESCRIPTION
@cognitom I also updated to set css to empty when it holds the attributes so it will not inject attributes.

re. #680 