### PR TITLE
Provide the standard way to share mixins over files

### DIFF
--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -242,28 +242,28 @@ Inside the tag the options can be referenced with the `opts` variable as follows
 
 ### Mixins
 
-Mixins provide an easy way to share functionality across tags. When a tag is compiled by riot, any defined mixins are added and available to use in the tag. 
+Mixins provide an easy way to share functionality across tags. When a tag is compiled by riot, any defined mixins are added and available to use in the tag.
 
 ```
 var OptsMixin = {
     'getOpts': function() {
         return this.opts
     },
-    
+
     'setOpts': function(opts, update) {
         this.opts = opts
-        
+
         if(!update) {
             this.update()
         }
-        
+
         return this
     }
 }
 
 <my-tag>
     <h1>{ opts.title }</h1>
-    
+
     this.mixin(OptsMixin)
 </my-tag>
 ```
@@ -291,12 +291,30 @@ var id_mixin_instance = new IdMixin()
 
 <my-tag>
     <h1>{ opts.title }</h1>
-    
+
     this.mixin(OptsMixin, id_mixin_instance)
 </my-tag>
 ```
 
 By being defined on the tag level, mixins not only extend the functionality of your tag, but also allows for a repeatable interface. Every time a tag is mounted, even sub-tags, the instance will have the mixed-in code.
+
+### Sharing mixin
+
+To share the mixins over files or projects, `riot.mixin` API is provided. You can register your mixin globally like this:
+
+```javascript
+riot.mixin('mixinName', mixinObject)
+```
+
+To load the mixin to the tag, use `mixin()` method with the key.
+
+```
+<my-tag>
+    <h1>{ opts.title }</h1>
+
+    this.mixin('mixinName')
+</my-tag>
+```
 
 
 ### Tag lifecycle

--- a/lib/browser/mixin.js
+++ b/lib/browser/mixin.js
@@ -1,0 +1,7 @@
+riot.mixin = (function() {
+  var registeredMixins = {}
+  return function(name, mixin) {
+    if (!mixin) return registeredMixins[name]
+      else registeredMixins[name] = mixin
+  }
+})()

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -65,6 +65,8 @@ function Tag(impl, conf, innerHTML) {
 
   this.mixin = function() {
     each(arguments, function(mix) {
+      if ('string' == typeof mix)
+        mix = riot.mixin(mix)
       extend(self, mix)
     })
   }

--- a/lib/riot.js
+++ b/lib/riot.js
@@ -1,5 +1,6 @@
 import 'browser/wrap/prefix'
 import 'browser/observable'
+import 'browser/mixin'
 import 'browser/router'
 import 'browser/tmpl'
 import 'browser/tag/each'

--- a/test/specs/mixin.js
+++ b/test/specs/mixin.js
@@ -122,4 +122,19 @@ describe('Mixin', function() {
     tag.unmount()
   })
 
+  it('register a mixin to Riot and load mixin to a tag', function() {
+    var mix = document.createElement('my-mixin')
+    document.body.appendChild(mix)
+
+    riot.mixin('idMixin', IdMixin) // register mixin
+    riot.tag('my-mixin', '<span>some tag</span>', function(opts) {
+      this.mixin('idMixin') // load mixin
+    })
+
+    var tag = riot.mount('my-mixin')[0]
+
+    expect(tag._id).to.be(tag.getId())
+    tag.unmount()
+  })
+
 })


### PR DESCRIPTION
This PR is just a little extension of @emehrkay's one and provides the standard way to share mixins over files. #536 

```javascript
// my-mixin.js
riot.mixin('myMixin', {
  message: 'Hello!'
})
```

```javascript
// my-tag.tag
<my-tag>
  <p>{ message }</p>
  this.mixin('myMixin')
</my-tag>
```