### PR TITLE
Added setting autoUpdate so we can turn off auto update after events

### DIFF
--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -23,15 +23,6 @@ riot.settings.brackets = '{{ }}'
 let's you write expressions `<p>{{ like_this }}</p>`. The start and end is separated with a space character.
 
 
-### riot.settings.autoUpdate | #autoUpdate
-
-A global Riot setting you can use if you want to turn off automatic updating after an event handler is called.
-
-``` js
-riot.settings.autoUpdate = false
-```
-
-
 <include tags.md />
 <include compiler.md />
 <include observable.md />

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -17,10 +17,19 @@ A global Riot setting to customize the start and end tokens of the expressions. 
 
 
 ``` js
-riot.settings.brackets = '\{\{ }}'
+riot.settings.brackets = '{{ }}'
 ```
 
-let's you write expressions `<p>\{\{ like_this }}</p>`. The start and end is separated with a space character.
+let's you write expressions `<p>{{ like_this }}</p>`. The start and end is separated with a space character.
+
+
+### riot.settings.autoUpdate | #autoUpdate
+
+A global Riot setting you can use if you want to turn off automatic updating after an event handler is called.
+
+``` js
+riot.settings.autoUpdate = false
+```
 
 
 <include tags.md />

--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -328,7 +328,7 @@ A tag is created in following sequence:
 
 After the tag is mounted the expressions are updated as follows:
 
-1. Automatically after an event handler is called. For example the `toggle` method in the above example.
+1. Automatically after an event handler is called.  (unless riot.settings.autoUpdate is set to false) For example the `toggle` method in the above example.
 2. When `this.update()` is called on the current tag instance
 3. When `this.update()` is called on a parent tag, or any parent upwards. Updates flow uni-directionally from parent to child.
 4. When `riot.update()` is called, which globally updates all expressions on the page.
@@ -735,7 +735,7 @@ Event handlers can access individual items in a collection with `event.item`. No
 </todo>
 ```
 
-After the event handler is executed the current tag instance is updated using `this.update()` which causes all the looped items to execute as well. The parent notices that an item has been removed from the collection and removes the corresponding DOM node from the document.
+After the event handler is executed the current tag instance is updated using `this.update()` (unless riot.settings.autoUpdate is set to false) which causes all the looped items to execute as well. The parent notices that an item has been removed from the collection and removes the corresponding DOM node from the document.
 
 
 ### Looping custom tags

--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -328,7 +328,7 @@ A tag is created in following sequence:
 
 After the tag is mounted the expressions are updated as follows:
 
-1. Automatically after an event handler is called.  (unless riot.settings.autoUpdate is set to false) For example the `toggle` method in the above example.
+1. Automatically after an event handler is called. (unless you set e.preventUpdate to true in your event handler) For example the `toggle` method in the above example.
 2. When `this.update()` is called on the current tag instance
 3. When `this.update()` is called on a parent tag, or any parent upwards. Updates flow uni-directionally from parent to child.
 4. When `riot.update()` is called, which globally updates all expressions on the page.
@@ -735,7 +735,7 @@ Event handlers can access individual items in a collection with `event.item`. No
 </todo>
 ```
 
-After the event handler is executed the current tag instance is updated using `this.update()` (unless riot.settings.autoUpdate is set to false) which causes all the looped items to execute as well. The parent notices that an item has been removed from the collection and removes the corresponding DOM node from the document.
+After the event handler is executed the current tag instance is updated using `this.update()` (unless you set e.preventUpdate to true in your event handler) which causes all the looped items to execute as well. The parent notices that an item has been removed from the collection and removes the corresponding DOM node from the document.
 
 
 ### Looping custom tags

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -16,7 +16,7 @@ function setEventHandler(name, handler, dom, tag, item) {
       e.returnValue = false
     }
 
-    if (riot.settings.autoUpdate) {
+    if (!e.preventUpdate) {
       var el = item ? tag.parent : tag
       el.update()
     }

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -16,8 +16,10 @@ function setEventHandler(name, handler, dom, tag, item) {
       e.returnValue = false
     }
 
-    var el = item ? tag.parent : tag
-    el.update()
+    if (riot.settings.autoUpdate) {
+      var el = item ? tag.parent : tag
+      el.update()
+    }
 
   }
 

--- a/lib/browser/wrap/prefix.js
+++ b/lib/browser/wrap/prefix.js
@@ -5,5 +5,5 @@
   // it leads to the following error on firefox "setting a property that has only a getter"
   //'use strict'
 
-  var riot = { version: 'WIP', settings: { autoUpdate: true } },
+  var riot = { version: 'WIP', settings: {} },
       ieVersion = checkIE()

--- a/lib/browser/wrap/prefix.js
+++ b/lib/browser/wrap/prefix.js
@@ -5,5 +5,5 @@
   // it leads to the following error on firefox "setting a property that has only a getter"
   //'use strict'
 
-  var riot = { version: 'WIP', settings: {} },
+  var riot = { version: 'WIP', settings: { autoUpdate: true } },
       ieVersion = checkIE()


### PR DESCRIPTION
In Riot after an event handler is being called el.update() is automatically called, but since this update is sometimes called too early or when we don't want to call update I added this feature to make it possible to turn off automatic update calls. An example is when you make an AJAX request in your event handler, the result right now is that update is called before the AJAX call returns and that is most often not what we want to do. In these cases it is better to call this.update() manually in your event handler.

Also, there is a problem if the event handler method that is called is in a parent or parent.parent tag, like in this example:
http://jsfiddle.net/AndreasHeintze/67nznL8p/
Here the event handler method is in the parent tag and since el.update() is called on the current tag, nothing will get updated. In this case it is better to turn off auto updating and call this.update() manually in the event handler, like in this example:
http://jsfiddle.net/AndreasHeintze/67nznL8p/29/

Of course we can manually call this.update() in our event handlers without this fix, but the result of that is that update is called twice and I think we should avoid that.

Also the added code in this fix is very small.

/Andreas