### PR TITLE
Syntax checker for tag files

### DIFF
--- a/lib/server/analyzer.js
+++ b/lib/server/analyzer.js
@@ -1,0 +1,100 @@
+/**
+ * Syntax checker for Riot.js
+ */
+
+/*
+ANALYZING STEPS:
+
+1. Devide into blocks by line-level analysis
+2. Validate Tag file layout
+3. TODO: validate Riot template
+4. TODO: validate script in tag
+5. TODO: validate style in tag
+6. TODO: validate js outside
+*/
+
+var LINE_TAG = /^<([\w\-]+)>(.*)<\/\1>\s*$/,
+  TAG_START = /^<([\w\-]+)\s?([^>]*)>\s*$/,
+  TAG_END = /^<\/([\w\-]+)>\s*$/,
+  HTML_END_DETECTOR = /<\/([\w\-]+)>\s*$/,
+  INVALID_TAG = /^</,
+  STYLE_START = /^\s+<style\s?([^>]*)>\s*$/,
+  STYLE_END = /^\s+<\/style>\s*$/,
+  SCRIPT_START = /^\s+<script\s?([^>]*)>\s*$/,
+  SCRIPT_END = /^\s+<\/script>\s*$/
+
+var ERR_TAG_UNMATCH = 'Closing tag unmatch',
+  ERR_NO_INDENT = 'Indentation needed within tag definition',
+  ERR_INVALID_TAG = 'Invalid tag flagment',
+  ERR_TAG_NOT_CLOSED = 'Last tag definition is not closed'
+
+function analyze(source) {
+  var mode = 'outside',// outside | tag_start | tag | tag_end | template | script | style
+    tag = ''
+
+  var results = source.split('\n').map(function(row, n) {
+    var m, err = '', type
+
+    if (m = row.match(TAG_START)) {
+      // Custam tag starting
+      type = 'tag_start'
+      if (mode == 'tag') { err = ERR_NO_INDENT }
+      else { tag = m[1]; mode = 'tag' }
+    } else if (m = row.match(TAG_END)) {
+      // Custam tag ending
+      type = 'tag_end'
+      if (tag != m[1]) { err = ERR_TAG_UNMATCH }
+      else { tag = ''; mode = 'outside' }
+    } else if (m = row.match(LINE_TAG)) {
+      // Custom line tag
+      if (mode == 'tag') { type = mode; err = ERR_NO_INDENT }
+      else { type = 'line_tag'; tag = ''; mode = 'outside' }
+    } else if (m = row.match(INVALID_TAG)) {
+      // Other invalid tags
+      if (mode == 'tag') err = ERR_NO_INDENT
+        else err = ERR_INVALID_TAG
+      type = mode
+    } else if (m = row.match(STYLE_START)) {
+      // Style starting
+      type = 'style_start'; mode = 'style'; block = ''
+    } else if (m = row.match(STYLE_END)) {
+      // Style ending
+      type = 'style_end'; mode = 'tag'; block = ''
+    } else if (m = row.match(SCRIPT_START)) {
+      // Script starting
+      type = 'script_start'; mode = 'script'; block = ''
+    } else if (m = row.match(SCRIPT_END)) {
+      // Script ending
+      type = 'script_end'; mode = 'tag'; block = ''
+    } else {
+      if (m = row.match(HTML_END_DETECTOR)) type = 'template'
+        else type = mode
+    }
+
+    return {
+      line: 'L' + (n + 1),
+      source: row,
+      type: type,
+      error: err
+    }
+  })
+
+  results.push({
+    line: 'EOF',
+    source: '',
+    type: 'end_of_file',
+    error: (mode == 'outside') ? '' : ERR_TAG_NOT_CLOSED
+  })
+
+  // scan backward to detect script block in tag
+  for (var t, i = results.length - 1; 0 <= i; i--) {
+    t = results[i].type
+    if ('tag_end' == t) mode = 'script'
+      else if ('template' == t || 'style' == t || 'script' == t) mode = 'template'
+        else if ('tag' == t) results[i].type = mode
+  }
+
+  return results
+}
+
+module.exports = analyze

--- a/lib/server/cli.js
+++ b/lib/server/cli.js
@@ -14,7 +14,23 @@
 var ph = require('path'),
   sh = require('shelljs'),
   chokidar = require('chokidar'),
-  compiler = require('./compiler')
+  chalk = require('chalk'),
+  compiler = require('./compiler'),
+  analyzer = require('./analyzer'),
+  TEMP_FILE_NAME = /\/[^.~][^~/]+$/ // skip temporary files (created by editors), e.g. /.name.tag, /~name.tag, /name~.tag
+
+var ext
+
+function find(from) {
+  return sh.find(from).filter(function(f) {
+    return ext.test(f) && TEMP_FILE_NAME.test(f)
+  })
+}
+function remap(from, to, base) {
+  return from.map(function(from) {
+    return ph.join(to, ph.relative(base, from).replace(ext, '.js'))
+  })
+}
 
 var methods = {
 
@@ -71,12 +87,6 @@ var methods = {
     init(opt)
 
     // Generate a list of input/output files
-
-    var tmp = /\/[^.~][^~/]+$/ // skip temporary files (created by editors), e.g. /.name.tag, /~name.tag, /name~.tag
-    function find(from) { return sh.find(from).filter(function(f) { return ext.test(f) && tmp.test(f) }) }
-    function remap(from, to, base) { return from.map(function(from) {
-      return ph.join(to, ph.relative(base, from).replace(ext, '.js'))
-    }) }
 
     var from = opt.flow[0] == 'f' ? [opt.from] : find(opt.from),
       base = opt.flow[0] == 'f' ? ph.dirname(opt.from) : opt.from,
@@ -140,11 +150,28 @@ var methods = {
       .on('ready', function() { log('Watching ' + toRelative(glob)) })
       .on('all', function(e, path) { methods.make(opt) })
 
+  },
+
+  check: function(opt) {
+    init(opt)
+
+    //TODO: analyze each file separatedly
+    var from = opt.flow[0] == 'f' ? [opt.from] : find(opt.from)
+    var source = sh.cat(from).replace(/^\uFEFF/g, /* strips BOM */'')
+    var errors = analyzer(source).filter(function(result) { return result.error })
+
+    if (errors.length) {
+      log(chalk.white.bgRed(' Riot Tag Syntax Error '))
+      errors.map(function(result) {
+        log(chalk.gray(result.line + '| ') + result.source)
+        log(chalk.red('^^^ ' + result.error))
+      })
+      log(chalk.gray('Total error: ' + errors.length))
+    } else {
+      log(chalk.green('No syntax error. Ready to compile :)'))
+    }
   }
 }
-
-
-var ext
 
 function init(opt) {
 
@@ -179,7 +206,7 @@ function cli() {
   // Get CLI arguments
 
   var args = require('minimist')(process.argv.slice(2), {
-    boolean: ['watch', 'compact', 'help', 'version', 'whitespace', 'modular'],
+    boolean: ['watch', 'compact', 'help', 'version', 'whitespace', 'modular', 'check'],
     alias: { w: 'watch', c: 'compact', h: 'help', v: 'version', t: 'type', m: 'modular' }
   })
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "riot.js"
   ],
   "dependencies": {
+    "chalk": "^1.0.0",
     "chokidar": "~1.0.1",
     "minimist": "~1.1.1",
     "shelljs": "~0.4.0",

--- a/test/runner.js
+++ b/test/runner.js
@@ -8,6 +8,7 @@ describe('Riot Tests', function() {
     require('./specs/node')
     require('./specs/tmpl')
     require('./specs/compiler-cli')
+    require('./specs/analyzer')
   } else {
     mocha.run()
   }

--- a/test/specs/analyzer/fixtures/invalid.tag
+++ b/test/specs/analyzer/fixtures/invalid.tag
@@ -1,0 +1,19 @@
+var riot = require('riot')
+
+<valid-tag>
+  <h1>{ title }</h1>
+  <p>{ message }</p>
+<invalid-flagment
+  this.title = 'Hello world!'
+  this.message = 'I am hungry...'
+</valid-tag>
+
+<invalid-t
+  <h1>{ title }</h1>
+  <p>{ message }</p>
+
+  this.title = 'Hello world!'
+  this.message = 'I am hungry...'
+</invalid-t
+
+console.log('end of file')

--- a/test/specs/analyzer/fixtures/tag-not-closed.tag
+++ b/test/specs/analyzer/fixtures/tag-not-closed.tag
@@ -1,0 +1,2 @@
+<tag-not-closed>
+  <p>Hello!</p>

--- a/test/specs/analyzer/fixtures/tag-unmatch.tag
+++ b/test/specs/analyzer/fixtures/tag-unmatch.tag
@@ -1,0 +1,4 @@
+<tag-unmatch>
+  <p>Hello!</p>
+  </tag-unmatch>
+</tag-unmatched>

--- a/test/specs/analyzer/fixtures/valid.tag
+++ b/test/specs/analyzer/fixtures/valid.tag
@@ -1,0 +1,27 @@
+var riot = require('riot')
+
+<valid-tag>
+  <h1>{ title }</h1>
+  <p>{ message }</p>
+
+  this.title = 'Hello world!'
+  this.message = 'I am hungry...'
+</valid-tag>
+
+<tag-with-style>
+  <p>Hi!</p>
+  <style scoped>
+    p { color: red }
+  </style>
+</tag-with-style>
+
+<tag-with-script>
+  <h1>{ title }</h1>
+  <p>{ message }</p>
+  <script>
+    this.title = 'Hello world!'
+    this.message = 'I am hungry...'
+  </script>
+</tag-with-script>
+
+console.log('end of file')

--- a/test/specs/analyzer/fixtures/valid.tag
+++ b/test/specs/analyzer/fixtures/valid.tag
@@ -8,6 +8,8 @@ var riot = require('riot')
   this.message = 'I am hungry...'
 </valid-tag>
 
+<line-tag>Hello { opts.message }!</line-tag>
+
 <tag-with-style>
   <p>Hi!</p>
   <style scoped>

--- a/test/specs/analyzer/fixtures/without-indent.tag
+++ b/test/specs/analyzer/fixtures/without-indent.tag
@@ -1,0 +1,5 @@
+<without-indent>
+<p>Without indent</p>
+<div>
+  Without indent</div>
+</without-indent>

--- a/test/specs/analyzer/index.js
+++ b/test/specs/analyzer/index.js
@@ -1,0 +1,30 @@
+var analyzer = require('../../../lib/server/analyzer')
+var fs = require('fs')
+var path = require('path')
+
+function cat(filename) {
+  return fs.readFileSync(path.join(__dirname, 'fixtures', filename)).toString()
+}
+
+describe('Syntax checker', function() {
+
+  it('returns no error if the tag is valid', function() {
+    var errors = analyzer(cat('valid.tag')).filter(function(r) { return r.error })
+    expect(errors.length).to.equal(0)
+  })
+  it('returns an error if the tag is not closed', function() {
+    var results = analyzer(cat('tag-not-closed.tag'))
+    expect(results[3].error).to.equal('Last tag definition is not closed')
+  })
+  it('returns an error if there are unmatched closing tags', function() {
+    var results = analyzer(cat('tag-unmatch.tag'))
+    expect(results[3].error).to.equal('Closing tag unmatch')
+    expect(results[5].error).to.equal('Last tag definition is not closed')
+  })
+  it('returns an error if there are no indentations within tag', function() {
+    var results = analyzer(cat('without-indent.tag'))
+    expect(results[1].error).to.equal('Indentation needed within tag definition')
+    expect(results[2].error).to.equal('Indentation needed within tag definition')
+  })
+
+})

--- a/test/specs/analyzer/index.js
+++ b/test/specs/analyzer/index.js
@@ -26,5 +26,11 @@ describe('Syntax checker', function() {
     expect(results[1].error).to.equal('Indentation needed within tag definition')
     expect(results[2].error).to.equal('Indentation needed within tag definition')
   })
+  it('returns an error if there are invalid tag flagments', function() {
+    var results = analyzer(cat('invalid.tag'))
+    expect(results[5].error).to.equal('Indentation needed within tag definition')
+    expect(results[10].error).to.equal('Invalid tag flagment')
+    expect(results[16].error).to.equal('Invalid tag flagment')
+  })
 
 })


### PR DESCRIPTION
At this time, it's just a line-level analyzer of the code. But maybe enough for #514

```bash
$ riot --check example.tag
```

![riotjs bash 76x10](https://cloud.githubusercontent.com/assets/16032/7553989/938f1a96-f74e-11e4-987a-95cf0cd91f0c.png)

I'm happy if someone reviews it :)
@GianlucaGuarini @nns2009