### PR TITLE
use name attribute in tags property for statically named child tags

### DIFF
--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -11,7 +11,8 @@ function parseNamedElements(root, parent, childTags) {
 
       if (child && !dom.isLoop) {
         var tag = new Tag(child, { root: dom, parent: parent }, dom.innerHTML),
-            tagName = child.name,
+            namedTag = dom.getAttribute('name'),
+            tagName = namedTag && namedTag.indexOf(brackets(0)) < 0 ? namedTag : child.name,
             ptag = parent,
             cachedTag
 

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -241,7 +241,12 @@ describe('Compiler Browser', function() {
 
           // precompiled tag compatibility
 
-          '<precompiled><\/precompiled>'
+          '<precompiled><\/precompiled>',
+
+          // static named tag
+
+          '<script type=\"riot\/tag\" src=\"tag\/named-child.tag\"><\/script>',
+          '<named-child-parent><\/named-child-parent>'
 
 
 
@@ -746,6 +751,11 @@ describe('Compiler Browser', function() {
     expect(window.getComputedStyle(tag.root, null).color).to.be('rgb(255, 0, 0)')
     tags.push(tag)
 
+  })
+
+  it('static named tag for tags property', function() {
+    var tag = riot.mount('named-child-parent')[0]
+    expect(tag.tags['tags-child'].root.innerHTML).to.be('I have a name')
   })
 
 })

--- a/test/tag/named-child.tag
+++ b/test/tag/named-child.tag
@@ -1,0 +1,5 @@
+<named-child-parent>
+  <named-child name="tags-child"></named-child>
+</named-child-parent>
+
+<named-child>I have a name</named-child>


### PR DESCRIPTION
#709 

If it is dynamically named,  `this.tags.tagname[0-n]` since name is not available at parse, same as previous update to tags property.

otherwise, use name attribute if available, if not the tagname