### PR TITLE
Fix isLoop on ie8 - Update parse.js

### DIFF
--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -4,6 +4,7 @@ function parseNamedElements(root, parent, childTags) {
 
   walk(root, function(dom) {
     if (dom.nodeType == 1) {
+      dom.isLoop = 0
       if(dom.parentNode && dom.parentNode.isLoop) dom.isLoop = 1
       if(dom.getAttribute('each')) dom.isLoop = 1
       // custom child tag


### PR DESCRIPTION
On Ie8 dom.isLoop is always 1 because isLoop isnt defined.