### PR TITLE
Add the interface for initializing the mixin

### DIFF
--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -246,11 +246,15 @@ Mixins provide an easy way to share functionality across tags. When a tag is com
 
 ```
 var OptsMixin = {
-    'getOpts': function() {
+    init: function() {
+      this.on('updated', function() { console.log('Updated!') })
+    }
+
+    getOpts: function() {
         return this.opts
     },
 
-    'setOpts': function(opts, update) {
+    setOpts: function(opts, update) {
         this.opts = opts
 
         if(!update) {
@@ -268,7 +272,7 @@ var OptsMixin = {
 </my-tag>
 ```
 
-In this example you are giving any instance of the `my-tag` Tag the `OptsMixin` which provides `getOpts` and `setOpts` methods.
+In this example you are giving any instance of the `my-tag` Tag the `OptsMixin` which provides `getOpts` and `setOpts` methods. `init` method is special one which can initialize the mixin when it's loaded to the tag. (`init` method is not accessible from other method)
 
 ```
 var my_tag_instance = riot.mount('my-tag')[0]

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -68,7 +68,10 @@ function Tag(impl, conf, innerHTML) {
       mix = 'string' == typeof mix ? riot.mixin(mix) : mix
       each(Object.keys(mix), function(key) {
         // bind methods to self
-        self[key] = 'function' == typeof mix[key] ? mix[key].bind(self) : mix[key]
+        self[key] = 'function' == typeof mix[key] && 'init' != key
+                  ? mix[key].bind(self) : mix[key]
+        // init method will be called automatically
+        if (mix.init) mix.init.bind(self)()
       })
     })
   }

--- a/test/specs/mixin.js
+++ b/test/specs/mixin.js
@@ -22,6 +22,13 @@ describe('Mixin', function() {
     }
   }
 
+  var MixinWithInit = {
+    init: function() {
+      this.message = 'initialized'
+    },
+    message: 'not yet'
+  }
+
   it('Will mount a tag and provide mixed-in methods', function() {
     var mix = document.createElement('my-mixin')
     document.body.appendChild(mix)
@@ -133,6 +140,20 @@ describe('Mixin', function() {
     var tag = riot.mount('my-mixin')[0]
 
     expect(tag.root.innerHTML).to.be('<span>some tag ' + tag._id + '</span>')
+    tag.unmount()
+  })
+
+  it('initializes the mixin', function() {
+    var mix = document.createElement('my-mixin')
+    document.body.appendChild(mix)
+
+    riot.tag('my-mixin', '<span>some tag</span>', function(opts) {
+      this.mixin(MixinWithInit)
+    })
+
+    var tag = riot.mount('my-mixin')[0]
+
+    expect(tag.message).to.be('initialized')
     tag.unmount()
   })
 


### PR DESCRIPTION
```javascript
riot.mixin('my-mixin', {
    init: function() {
      this.on('updated', function() { console.log('Updated!') })
    },
    message: 'Hello world!'
})

<my-tag>
    <p>{ message }</p>
    this.mixin('my-mixin')
    this.init() // I want to remove this line...
</my-tag>
```

I've realized that (almost) all mixins need some code to init it: adding event listeners or something. Is it better to wait for next 2.0.17 release?