### PR TITLE
Allow top level attribute manipulations.

### DIFF
--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -30,7 +30,7 @@ function Tag(impl, conf, innerHTML) {
   each(root.attributes, function(el) {
     var val = el.value
     // remember attributes with expressions only
-    if (/\{.*\}/.test(val)) attr[el.name] = val
+    if (brackets(/\{.*\}/).test(val)) attr[el.name] = val
   })
 
 

--- a/lib/tag/tag.js
+++ b/lib/tag/tag.js
@@ -28,7 +28,9 @@ function Tag(impl, conf, innerHTML) {
 
   // grab attributes
   each(root.attributes, function(el) {
-    attr[el.name] = el.value
+    var val = el.value
+    // remember attributes with expressions only
+    if (/\{.*\}/.test(val)) attr[el.name] = val
   })
 
 
@@ -39,6 +41,11 @@ function Tag(impl, conf, innerHTML) {
 
   // options
   function updateOpts() {
+    // update opts from current DOM attributes
+    each(root.attributes, function(el) {
+      opts[el.name] = tmpl(el.value, parent || self)
+    })
+    // recover those with expressions
     each(Object.keys(attr), function(name) {
       opts[name] = tmpl(attr[name], parent || self)
     })

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -25,7 +25,8 @@ module.exports = function(config) {
           'specs/observable.js',
           'specs/route.js',
           'specs/tmpl.js',
-          'specs/speed.js'
+          'specs/speed.js',
+          'specs/tag.js'
       ],
       browsers: ['PhantomJS'],
 

--- a/test/specs/tag.js
+++ b/test/specs/tag.js
@@ -1,0 +1,35 @@
+describe('Tag', function() {
+  it('top level attr manipulation', function() {
+    var div = document.createElement('div')
+    div.innerHTML = [
+      '<top-level-attr value="initial"></top-level-attr>'
+    ].join('\r')
+    document.body.appendChild(div)
+
+    riot.tag('top-level-attr', '{opts.value}')
+
+    var tag = riot.mount('top-level-attr')[0]
+
+    tag.root.setAttribute('value', 'changed')
+    tag.update()
+
+    expect(tag.root.innerHTML).to.be('changed')
+  })
+
+  it('top level attr manipulation having expression', function() {
+    var div = document.createElement('div')
+    div.innerHTML = [
+      '<top-level-attr value="initial"></top-level-attr>'
+    ].join('\r')
+    document.body.appendChild(div)
+
+    riot.tag('top-level-attr', '{opts.value}')
+
+    var tag = riot.mount('top-level-attr')[0]
+
+    tag.root.setAttribute('value', '{1+1}')
+    tag.update()
+
+    expect(tag.root.innerHTML).to.be('2')
+  })
+})


### PR DESCRIPTION
Say you have a top level (not within a tag file) component like this:

```html
<my-input-text id="example" preicon="icon-facebook" placeholder="Example here"></my-input-text>
```

When I try to modify an attribute, say `placeholder`, and update, nothing happens, because tag instance's `opts` are overridden with the old attributes every time it updates.

This is so attributes with expressions can be correctly updated. However, this prevents top level attribute modifications. Mounting with `opts` is a solution, but it is impractical if there are many small top level components. Users should be able to modify top level components' attributes through Riot.

This PR recognizes if an attribute contains expressions or not, and only override when it does contain expressions, otherwise, it will update the `opts` from DOM attributes.