### PR TITLE
Fix #783

### DIFF
--- a/lib/shared/compiler.js
+++ b/lib/shared/compiler.js
@@ -142,8 +142,9 @@ function riotjs(js) {
 function scopedCSS (tag, style, type) {
   return style.replace(CSS_COMMENT, '').replace(CSS_SELECTOR, function (m, p1, p2) {
     return p1 + ' ' + p2.split(/\s*,\s*/g).map(function(sel) {
-      var s = sel.replace(/:scope\s*/, '')
-      return sel[0] == '@' ? sel : tag + ' ' + s +', [riot-tag="'+tag+'"] ' + s
+      var s = sel.trim().replace(/:scope\s*/, '')
+      return s[0] == '@' || s == 'from' || s == 'to' ? s :
+        tag + ' ' + s + ', [riot-tag="' + tag + '"] ' + s
     }).join(',')
   }).trim()
 }

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -784,8 +784,8 @@ describe('Compiler Browser', function() {
     var stag = document.querySelector('style'),
       styles =  normalizeHTML(stag.styleSheet ? stag.styleSheet.cssText : stag.innerHTML)
 
-    expect(styles).to.match(/p {color: blue;}/)
-    expect(styles).to.match(/div {color: red;}/)
+    expect(styles).to.match(/p{color: blue;}/)
+    expect(styles).to.match(/div{color: red;}/)
   })
 
   it('scoped css and riot-tag, mount(selector, tagname)', function() {

--- a/test/specs/compiler/scoped-css.js
+++ b/test/specs/compiler/scoped-css.js
@@ -6,31 +6,31 @@ describe('Scoped CSS', function() {
 
   it('add my-tag to the simple selector', function() {
     expect(render('h1 { font-size: 150% }'))
-        .to.equal('my-tag h1 , [riot-tag="my-tag"] h1 { font-size: 150% }')
+        .to.equal('my-tag h1, [riot-tag="my-tag"] h1{ font-size: 150% }')
   })
   it('add my-tag to the multi selector in a line', function() {
     expect(render('h1 { font-size: 150% } #id { color: #f00 }'))
-        .to.equal('my-tag h1 , [riot-tag="my-tag"] h1 { font-size: 150% } my-tag #id , [riot-tag="my-tag"] #id { color: #f00 }')
+        .to.equal('my-tag h1, [riot-tag="my-tag"] h1{ font-size: 150% } my-tag #id, [riot-tag="my-tag"] #id{ color: #f00 }')
   })
   it('add my-tag to the complex selector', function() {
     expect(render('header a.button:hover { text-decoration: none }'))
-        .to.equal('my-tag header a.button:hover , [riot-tag="my-tag"] header a.button:hover { text-decoration: none }')
+        .to.equal('my-tag header a.button:hover, [riot-tag="my-tag"] header a.button:hover{ text-decoration: none }')
   })
   it('add my-tag to the comma-separated selector', function() {
     expect(render('h2, h3 { border-bottom: 1px solid #000 }'))
-        .to.equal('my-tag h2, [riot-tag="my-tag"] h2,my-tag h3 , [riot-tag="my-tag"] h3 { border-bottom: 1px solid #000 }')
+        .to.equal('my-tag h2, [riot-tag="my-tag"] h2,my-tag h3, [riot-tag="my-tag"] h3{ border-bottom: 1px solid #000 }')
   })
   it('add my-tag to the attribute selector', function() {
     expect(render('i[class=twitter] { background: #55ACEE }'))
-        .to.equal('my-tag i[class=twitter] , [riot-tag="my-tag"] i[class=twitter] { background: #55ACEE }')
+        .to.equal('my-tag i[class=twitter], [riot-tag="my-tag"] i[class=twitter]{ background: #55ACEE }')
   })
   it('add my-tag to the selector with a backslash', function() {
     expect(render('a:after { content: "*" }'))
-        .to.equal('my-tag a:after , [riot-tag="my-tag"] a:after { content: "*" }')
+        .to.equal('my-tag a:after, [riot-tag="my-tag"] a:after{ content: "*" }')
   })
   it('add my-tag to the selector with multi-line definitions', function() {
     expect(render('header {\n  text-align: center;\n  background: rgba(0,0,0,.2);\n}'))
-        .to.equal('my-tag header , [riot-tag="my-tag"] header { text-align: center; background: rgba(0,0,0,.2); }')
+        .to.equal('my-tag header, [riot-tag="my-tag"] header{ text-align: center; background: rgba(0,0,0,.2); }')
   })
   it('add my-tag to the root selector', function() {
     expect(render(':scope { display: block }'))
@@ -38,15 +38,19 @@ describe('Scoped CSS', function() {
   })
   it('add my-tag to the nested root selector', function() {
     expect(render(':scope > ul { padding: 0 }'))
-        .to.equal('my-tag > ul , [riot-tag="my-tag"] > ul { padding: 0 }')
+        .to.equal('my-tag > ul, [riot-tag="my-tag"] > ul{ padding: 0 }')
   })
   it('not add my-tag to @font-face', function() {
     expect(render('@font-face { font-family: "FontAwesome" }'))
-        .to.equal('@font-face { font-family: "FontAwesome" }')
+        .to.equal('@font-face{ font-family: "FontAwesome" }')
   })
   it('not add my-tag to @media, and add it to the selector inside', function() {
     expect(render('@media (min-width: 500px) {\n  header {\n    text-align: left;\n  }\n}'))
-        .to.equal('@media (min-width: 500px) { my-tag header , [riot-tag="my-tag"] header { text-align: left; } }')
+        .to.equal('@media (min-width: 500px){ my-tag header, [riot-tag="my-tag"] header{ text-align: left; } }')
+  })
+  it('not add my-tag to "from" and "to" in @keyframes', function() {
+    expect(render('@keyframes fade { from { opacity: 1; } to { opacity: 0; } }'))
+        .to.equal('@keyframes fade{ from{ opacity: 1; } to{ opacity: 0; } }')
   })
 
   it('use a custom css parser to render the css', function() {


### PR DESCRIPTION
This fixes the issue reported by @gregorypratt
In this case, `from` and `to` should be kept as is.

```css
@keyframes fade {
  from {
    opacity: 1;
  }
  to {
    opacity: 0;
  }
}
```