### PR TITLE
Additional fix for #783

### DIFF
--- a/lib/shared/compiler.js
+++ b/lib/shared/compiler.js
@@ -143,7 +143,7 @@ function scopedCSS (tag, style, type) {
   return style.replace(CSS_COMMENT, '').replace(CSS_SELECTOR, function (m, p1, p2) {
     return p1 + ' ' + p2.split(/\s*,\s*/g).map(function(sel) {
       var s = sel.trim().replace(/:scope\s*/, '')
-      return s[0] == '@' || s == 'from' || s == 'to' ? s :
+      return s[0] == '@' || s == 'from' || s == 'to' || /%$/.test(s) ? s :
         tag + ' ' + s + ', [riot-tag="' + tag + '"] ' + s
     }).join(',')
   }).trim()

--- a/test/specs/compiler/scoped-css.js
+++ b/test/specs/compiler/scoped-css.js
@@ -52,6 +52,10 @@ describe('Scoped CSS', function() {
     expect(render('@keyframes fade { from { opacity: 1; } to { opacity: 0; } }'))
         .to.equal('@keyframes fade{ from{ opacity: 1; } to{ opacity: 0; } }')
   })
+  it('not add my-tag to parsentage values in @keyframes', function() {
+    expect(render('@keyframes fade { 10% { opacity: 1; } 85% { opacity: 0; } }'))
+        .to.equal('@keyframes fade{ 10%{ opacity: 1; } 85%{ opacity: 0; } }')
+  })
 
   it('use a custom css parser to render the css', function() {
     riot.parsers.css.myParser = function(tag, css) {


### PR DESCRIPTION
This fixes the issue #783  reported by @gregorypratt
In this case, parentage-values like '20%' should be kept as is.

```css
@keyframes fade {
  20% {
    opacity: 1;
  }
  85% {
    opacity: 0;
  }
}
```

This is an additional PR to #785.