### PR TITLE
Multinamed

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -160,12 +160,6 @@ function _each(dom, parent, expr) {
 
     rendered = items.slice()
 
-  }).one('updated', function() {
-    walk(root, function(dom) {
-      each(dom.attributes, function(attr) {
-        if (/^(name|id)$/.test(attr.name)) parent[attr.value] = dom
-      })
-    })
   })
 
 }

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -46,7 +46,14 @@ function parseNamedElements(root, parent, childTags) {
 
       if(!dom.isLoop)
         each(dom.attributes, function(attr) {
-          if (/^(name|id)$/.test(attr.name)) parent[attr.value] = dom
+          if (/^(name|id)$/.test(attr.name)) {
+            if(parent[attr.value]) {
+              console.log('here', attr.value, parent, parent[attr.value])
+              if(Array.isArray(parent[attr.value])) parent[attr.value].push(dom)
+              else parent[attr.value] = [parent[attr.value], dom]
+            }
+            else parent[attr.value] = dom
+          }
         })
     }
 

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -290,9 +290,14 @@ describe('Compiler Browser', function() {
           '<script type=\"riot\/tag\" src=\"tag\/deferred-mount.tag\"><\/script>',
           '<deferred-mount><\/deferred-mount>',
 
+          // multi named elements to an array
+          '<script type=\"riot\/tag\" src=\"tag\/multi-named.tag\"><\/script>',
+          '<multi-named><\/multi-named>',
+
           // test the preventUpdate feature on the DOM events
           '<script type=\"riot\/tag\" src=\"tag\/prevent-update.tag\"><\/script>',
           '<prevent-update><\/prevent-update>'
+
 
     ].join('\r'),
       tags = [],
@@ -897,6 +902,14 @@ describe('Compiler Browser', function() {
     expect(mountingOrder.join()).to.be(correctMountingOrder.join())
 
     tags.push(tag)
+  })
+
+  it('multi named elements to an array', function() {
+    var tag = riot.mount('multi-named')[0]
+    expect(tag.rad[0].value).to.be('1')
+    expect(tag.rad[1].value).to.be('2')
+    expect(tag.rad[2].value).to.be('3')
+    tag.unmount()
   })
 
 })

--- a/test/tag/multi-named.tag
+++ b/test/tag/multi-named.tag
@@ -1,0 +1,5 @@
+<multi-named>
+  <input name="rad" type="radio" value="1">
+  <input name="rad" type="radio" value="2">
+  <input name="rad" type="radio" value="3">
+</multi-named>


### PR DESCRIPTION
If there are several elements with the same name, as is common with radio buttons and checkbox arrays, create named attribute as an array.  The current functionality will overwrite each time leaving only the most recent.  This is not serializable, which can be done in a mixin, with this fix and combined with the mixin will help overcome the lack of two way binding

Also, it appears that the second parse for dynamically named attributes is no longer needed, probably a result of fixing the event order